### PR TITLE
Develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
 
             echo "Running new container with image: ${{ env.DOCKER_IMAGE_NAME_LATEST }}"
             sudo docker run -d \
-              -p 80:8080 \
+              -p 8080:8080 \
               --name kiring-app \
               -e SPRING_PROFILES_ACTIVE=dev \
               -e DB_HOST="${{ secrets.DB_HOST }}" \

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ subprojects {
 
     dependencies {
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+        // Hibernate Spatial (JPA 공간 데이터 타입 지원)
+        implementation 'org.hibernate.orm:hibernate-spatial:6.5.2.Final' // Hibernate 6 버전에 맞는 버전 사용
+        // JTS (Java Topology Suite) Core - Point, Polygon 등 공간 데이터 객체 제공
+        implementation 'org.locationtech.jts:jts-core:1.19.0'
     }
 
     bootJar.enabled = false

--- a/core/core-api/build.gradle
+++ b/core/core-api/build.gradle
@@ -62,4 +62,7 @@ dependencies {
     // Feign Client (Kakao API 통신용)
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign' // Spring Cloud BOM 설정 필요
 
+    // Apache POI for Excel (.xlsx) - 엑셀 파일 처리를 위한 라이브러리
+    implementation 'org.apache.poi:poi-ooxml:5.2.5'
+
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/config/SecurityConfig.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of("http://localhost:*", "https://localhost:*", "https://kiring-develop.vercel.app"));
+        configuration.setAllowedOriginPatterns(List.of("http://localhost:*", "https://localhost:*", "https://*.vercel.app"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS","HEAD"));
         configuration.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
         configuration.setAllowCredentials(true);

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/config/SecurityConfig.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/config/SecurityConfig.java
@@ -78,8 +78,8 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of("http://localhost:*", "https://localhost:*", "http://43.202.199.39"));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedOriginPatterns(List.of("http://localhost:*", "https://localhost:*", "https://kiring-develop.vercel.app"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS","HEAD"));
         configuration.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600L); // Preflight 요청 캐시 시간 (1시간)

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/config/SecurityConfig.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/config/SecurityConfig.java
@@ -55,7 +55,9 @@ public class SecurityConfig {
                                 "/swagger-ui.html", // Swagger UI 접근 허용
                                 "/swagger-ui/**", // Swagger UI 리소스 접근 허용
                                 "/v3/api-docs/**", // Swagger API 문서 접근 허용
-                                "/auth/logout" // 로그아웃 경로는 인증된 사용자가 호출할 수 있도록 authenticated()에 두거나,
+                                "/auth/logout", // 로그아웃 경로는 인증된 사용자가 호출할 수 있도록 authenticated()에 두거나,
+                                "/api/v1/matzip/**",
+                                "/api/v1/member/**"
                         ).permitAll()// API 접근 허용
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/config/SecurityConfig.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/config/SecurityConfig.java
@@ -57,7 +57,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**", // Swagger API 문서 접근 허용
                                 "/auth/logout", // 로그아웃 경로는 인증된 사용자가 호출할 수 있도록 authenticated()에 두거나,
                                 "/api/v1/matzip/**",
-                                "/api/v1/member/**"
+                                "/api/v1/member/**",
+                                "/api/v1/health/**"
                         ).permitAll()// API 접근 허용
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/config/SecurityConfig.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/login/oauth2/code/**",
                                 "/oauth2/**", // OAuth2 인증 관련 API 접근 허용
+                                "/api/v1/auth/refresh", // RefreshToken API 허용
                                 "/login/oauth2/**", // 카카오 OAuth2 로그인 콜백
                                 "/swagger-ui.html", // Swagger UI 접근 허용
                                 "/swagger-ui/**", // Swagger UI 리소스 접근 허용

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/controller/AuthController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package io.dodn.springboot.auth.controller;
+
+import io.dodn.springboot.auth.controller.request.RefreshRequest;
+import io.dodn.springboot.auth.domain.AuthService;
+import io.dodn.springboot.auth.jwt.dto.TokenInfo;
+import io.dodn.springboot.common.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Operation(summary = "액세스 토큰 재발급", description = "만료된 액세스 토큰 대신 리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다.")
+    @PostMapping("/refresh")
+    public ApiResponse<TokenInfo> refreshToken(@RequestBody RefreshRequest request) {
+        TokenInfo newTokenInfo = authService.refreshToken(request.refreshToken());
+        return ApiResponse.success(newTokenInfo);
+    }
+
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/controller/request/RefreshRequest.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/controller/request/RefreshRequest.java
@@ -1,0 +1,8 @@
+package io.dodn.springboot.auth.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+        @NotBlank String refreshToken
+) {
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/domain/AuthService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/domain/AuthService.java
@@ -1,0 +1,65 @@
+package io.dodn.springboot.auth.domain;
+
+import io.dodn.springboot.auth.jwt.JwtTokenProvider;
+import io.dodn.springboot.auth.jwt.dto.TokenInfo;
+import io.dodn.springboot.common.support.error.CoreException;
+import io.dodn.springboot.common.support.error.ErrorType;
+import io.dodn.springboot.storage.db.member.MemberRepository;
+import io.dodn.springboot.storage.db.member.entity.Member;
+import io.jsonwebtoken.Claims;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Service
+public class AuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+    public AuthService(final JwtTokenProvider jwtTokenProvider, final MemberRepository memberRepository) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.memberRepository = memberRepository;
+    }
+
+
+    @Transactional // 사용자 정보 조회 시 트랜잭션 필요할 수 있음
+    public TokenInfo refreshToken(final String refreshToken) {
+        // 1. 리프레시 토큰 유효성 검증 및 클레임 추출
+        // validateRefreshTokenAndGetClaims 메서드 내부에서 만료, 서명 오류 등 처리
+        Claims claims = jwtTokenProvider.validationRefreshToeknAndGetClaims(refreshToken);
+
+        // 2. 리프레시 토큰에서 사용자 ID 추출
+        String memberIdStr = claims.getSubject();
+        if (memberIdStr == null) {
+            throw new CoreException(ErrorType.ERR_1099,"리프레시 토큰에 사용자 정보가 없습니다."); // ErrorType 수정
+        }
+        Long memberId = Long.valueOf(memberIdStr);
+
+        // 4. 사용자 정보(권한 포함) 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CoreException(ErrorType.ERR_1099, "리프레시 토큰의 사용자를 찾을 수 없습니다.")); // ErrorType 수정
+
+        // 5. 사용자 권한 가져오기 (Member 엔티티에서 권한 정보를 가져오는 로직 필요)
+        Collection<? extends GrantedAuthority> authorities = getAuthoritiesForMember(member); // Helper 메서드
+        // 6. 새로운 액세스 토큰 및 리프레시 토큰 생성
+        return jwtTokenProvider.generateToken(memberIdStr, authorities);
+    }
+
+    private Collection<? extends GrantedAuthority> getAuthoritiesForMember(Member member) {
+        List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+        // Member 엔티티에 역할(Role) 정보가 있다고 가정
+        // 예: member.getRole()이 "ADMIN" 또는 "USER" 반환
+        if (member.isAdmin()) {
+            authorities.add(new SimpleGrantedAuthority("ADMIN"));
+        }
+        authorities.add(new SimpleGrantedAuthority("USER"));
+
+        return authorities;
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/CustomOAuth2AuthorizationRequestResolver.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/CustomOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,79 @@
+package io.dodn.springboot.auth.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+    private static final Logger log = LoggerFactory.getLogger(CustomOAuth2AuthorizationRequestResolver.class);
+    public static final String CLIENT_REGISTRATION_ID_ATTRIBUTE_NAME = "client_registration_id";
+
+    private final OAuth2AuthorizationRequestResolver defaultResolver;
+
+    public CustomOAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
+                clientRegistrationRepository, "/oauth2/authorization");
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        log.info(">>> Custom resolver (1) is called!");
+
+        OAuth2AuthorizationRequest authorizationRequest = this.defaultResolver.resolve(request);
+        String registrationId = extractRegistrationIdFromRequest(request);
+        return addKakaoPrompt(authorizationRequest, registrationId);
+    }
+
+    private String extractRegistrationIdFromRequest(final HttpServletRequest request) {
+        String uri = request.getRequestURI(); // 예: /oauth2/authorization/kakao
+        String prefix = "/oauth2/authorization/";
+        if (uri.startsWith(prefix)) {
+            return uri.substring(prefix.length());
+        }
+        return null;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        log.info(">>> Custom resolver (2) for client '{}' is called!", clientRegistrationId);
+
+        OAuth2AuthorizationRequest authorizationRequest = this.defaultResolver.resolve(request, clientRegistrationId);
+        return addKakaoPrompt(authorizationRequest, clientRegistrationId);
+    }
+
+    private OAuth2AuthorizationRequest addKakaoPrompt(OAuth2AuthorizationRequest authorizationRequest, String clientRegistrationId) {
+        if (authorizationRequest == null) {
+            return null;
+        }
+
+        log.info(">>> Checking registrationId (from method param): [{}]", clientRegistrationId);
+
+        if ("kakao".equalsIgnoreCase(clientRegistrationId)) {
+            log.info(">>> Matched 'kakao'! Adding 'prompt=login' parameter.");
+
+            Map<String, Object> additionalParameters = new HashMap<>(authorizationRequest.getAdditionalParameters());
+            additionalParameters.put("prompt", "login");
+
+            // 기존 attributes 복사 + registrationId 강제 세팅
+            Map<String, Object> attributes = new HashMap<>(authorizationRequest.getAttributes());
+            attributes.put("client_registration_id", clientRegistrationId);
+
+            return OAuth2AuthorizationRequest.from(authorizationRequest)
+                    .additionalParameters(additionalParameters)
+                    .attributes(attributes)
+                    .build();
+        }
+
+        return authorizationRequest;
+    }
+
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/JwtTokenProvider.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/JwtTokenProvider.java
@@ -116,6 +116,26 @@ public class JwtTokenProvider {
         }
     }
 
+    public Claims validationRefreshToeknAndGetClaims(String refreshToken) {
+        try {
+            log.debug("Validation refresh token '{}' ", refreshToken);
+            return Jwts.parserBuilder()
+                    .setSigningKey(this.key)
+                    .build()
+                    .parseClaimsJws(refreshToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token: {}", e.getMessage());
+            throw new CoreException(ErrorType.ERR_1009, "Expired JWT token");
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT token: {}", e.getMessage());
+            throw new CoreException(ErrorType.ERR_1010, "Invalid JWT token");
+        } catch (Exception e) {
+            log.error("ERROR JWT token: {}", e.getMessage());
+            throw new CoreException(ErrorType.ERR_1010, "ERROR JWT TOKEN");
+        }
+    }
+
     private Claims parseClaims(final String accessToken) {
         try {
             log.debug("Parsing token: '[{}]'", accessToken);

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/JwtTokenProvider.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/JwtTokenProvider.java
@@ -35,7 +35,7 @@ public class JwtTokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; //30분
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = ACCESS_TOKEN_EXPIRE_TIME * 2; // Refresh token은 2배로 설정
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 30;
     private Key key;
 
     @Value("${jwt.secret}")

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/OAuth2AuthenticationSuccessHandler.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/OAuth2AuthenticationSuccessHandler.java
@@ -14,7 +14,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -56,7 +55,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             log.info("Kakao User Info (converted): ID={}, Nickname={}, Email={}", kakaoUserInfo.id(), kakaoUserInfo.getNickname(), kakaoUserInfo.getEmail());
         try {
             Member member = memberService.findOrCreateMemberByKakaoInfo(kakaoUserInfo);
-            List<GrantedAuthority> authorities = getAuthoritiesForUser(member);
+            List<SimpleGrantedAuthority> authorities = getAuthoritiesForUser(member);
 
             final TokenInfo tokenInfo = jwtTokenProvider.generateToken(String.valueOf(member.getId()), authorities);
             log.info("애플리케이션 JWT 발급: {}", tokenInfo);
@@ -110,15 +109,14 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     }
 
 
-    private List<GrantedAuthority> getAuthoritiesForUser(final Member member) {
-        List<GrantedAuthority> authorities = new ArrayList<>();
+    private List<SimpleGrantedAuthority> getAuthoritiesForUser(final Member member) {
+        List<SimpleGrantedAuthority> authorities = new ArrayList<>();
 
         // 사용자의 권한을 Enum으로 체크하여 권한을 리스트에 추가
         if (member.isAdmin()) {
             authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
-        } else {
-            authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
         }
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
 
         return authorities;
     }

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/OAuth2AuthenticationSuccessHandler.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/OAuth2AuthenticationSuccessHandler.java
@@ -3,7 +3,9 @@ package io.dodn.springboot.auth.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dodn.springboot.auth.jwt.dto.TokenInfo;
 import io.dodn.springboot.auth.kakao.dto.KakaoUserInfoResponse;
+import io.dodn.springboot.common.support.error.ErrorType;
 import io.dodn.springboot.member.domain.MemberService;
+import io.dodn.springboot.member.exception.NotFoundMemberException;
 import io.dodn.springboot.storage.db.member.entity.Member;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -65,15 +67,29 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
             getRedirectStrategy().sendRedirect(request, response, targetUrl);
 
-        } catch (Exception e) {
+        } catch (NotFoundMemberException e) {
             // 3. 실패: 사용자를 찾을 수 없다는 예외 발생 시 회원가입 페이지로 리다이렉트 , 폰번호가 없는 경우도 추가
             log.info("가입되지 않은 사용자입니다. 추가 정보 입력 페이지로 리다이렉트합니다. Kakao User Info: {}", kakaoUserInfo);
 
             final String targetUrl = UriComponentsBuilder.fromUriString(frontendTargetUrl)
                     .queryParam("email", kakaoUserInfo.getEmail())
-                    .queryParam("nickname", kakaoUserInfo.getNickname())
-                    .queryParam("profileImageUrl", kakaoUserInfo.getProfileImageUrl())
                     .queryParam("kakaoId", String.valueOf(kakaoUserInfo.id()))
+                    .queryParam("errorCode", ErrorType.NOT_FOUND_MEMBER)
+                    .queryParam("errorMessage", "가입되지 않은 사용자")
+                    .build()
+                    .encode() // URL 인코딩
+                    .toUriString();
+
+            getRedirectStrategy().sendRedirect(request, response, targetUrl);
+        } catch (Exception e) {
+            // 3. 실패: 계정에 폰번호가 없거나 나머지 서버 에러
+            log.info("계정에 폰번호가 없거나 나머지 서버 에러 추가 정보 입력 페이지로 리다이렉트합니다. Kakao User Info: {}", kakaoUserInfo);
+
+            final String targetUrl = UriComponentsBuilder.fromUriString(frontendTargetUrl)
+                    .queryParam("email", kakaoUserInfo.getEmail())
+                    .queryParam("nickname", kakaoUserInfo.getNickname())
+                    .queryParam("errorCode", ErrorType.DEFAULT_ERROR)
+                    .queryParam("errorMessage", "계정에 폰번호 존재하지않음 or 서버 에러")
                     .build()
                     .encode() // URL 인코딩
                     .toUriString();

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/OAuth2AuthenticationSuccessHandler.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/OAuth2AuthenticationSuccessHandler.java
@@ -3,10 +3,7 @@ package io.dodn.springboot.auth.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dodn.springboot.auth.jwt.dto.TokenInfo;
 import io.dodn.springboot.auth.kakao.dto.KakaoUserInfoResponse;
-import io.dodn.springboot.common.support.error.ErrorType;
-import io.dodn.springboot.common.support.response.ApiResponse;
 import io.dodn.springboot.member.domain.MemberService;
-import io.dodn.springboot.member.exception.NotFoundMemberException;
 import io.dodn.springboot.storage.db.member.entity.Member;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -68,8 +65,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
             getRedirectStrategy().sendRedirect(request, response, targetUrl);
 
-        } catch (NotFoundMemberException e) {
-            // 3. 실패: 사용자를 찾을 수 없다는 예외 발생 시 회원가입 페이지로 리다이렉트
+        } catch (Exception e) {
+            // 3. 실패: 사용자를 찾을 수 없다는 예외 발생 시 회원가입 페이지로 리다이렉트 , 폰번호가 없는 경우도 추가
             log.info("가입되지 않은 사용자입니다. 추가 정보 입력 페이지로 리다이렉트합니다. Kakao User Info: {}", kakaoUserInfo);
 
             final String targetUrl = UriComponentsBuilder.fromUriString(frontendTargetUrl)
@@ -82,9 +79,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                     .toUriString();
 
             getRedirectStrategy().sendRedirect(request, response, targetUrl);
-        } catch (Exception e) {
-            ApiResponse<?> errorResponse = ApiResponse.error(ErrorType.DEFAULT_ERROR, e.getMessage());
-            objectMapper.writeValue(response.getWriter(), errorResponse);
         } finally {
             clearAuthenticationAttributes(request);
         }

--- a/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/OAuth2AuthenticationSuccessHandler.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/auth/jwt/OAuth2AuthenticationSuccessHandler.java
@@ -61,13 +61,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             final TokenInfo tokenInfo = jwtTokenProvider.generateToken(String.valueOf(member.getId()), authorities);
             log.info("애플리케이션 JWT 발급: {}", tokenInfo);
 
-//            // --- JSON 응답으로 직접 TokenInfo 보내기 ---
-//            response.setStatus(HttpStatus.OK.value()); // HTTP 상태 코드 200 OK
-//            response.setContentType(MediaType.APPLICATION_JSON_VALUE); // Content Type을 JSON으로 설정
-//            response.setCharacterEncoding("UTF-8"); // 문자 인코딩 설정
-//
-//            // TokenInfo 객체를 JSON 문자열로 변환하여 응답 본문에 작성
-//            objectMapper.writeValue(response.getWriter(), tokenInfo);
             final String targetUrl = UriComponentsBuilder.fromUriString(frontendTargetUrl)
                             .queryParam("accessToken", tokenInfo.accessToken())
                             .queryParam("refreshToken", tokenInfo.refreshToken())

--- a/core/core-api/src/main/java/io/dodn/springboot/common/api/HealthController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/api/HealthController.java
@@ -4,9 +4,11 @@ import io.dodn.springboot.common.swagger.HealthDocs;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/v1/health")
 public class HealthController implements HealthDocs {
 
     @GetMapping("/health")

--- a/core/core-api/src/main/java/io/dodn/springboot/common/config/OpenApiConfig.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/config/OpenApiConfig.java
@@ -17,7 +17,7 @@ import org.springframework.context.annotation.Configuration;
                         url = "https://kiring.example.com"),
                 license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html")),
         servers = {
-                @Server(url = "http://13.124.210.210/", description = "Development Server"),
+                @Server(url = "https://api.kiring.shop/", description = "Development Server"),
                 @Server(url = "http://localhost:8080/", description = "Localhost Server")
         }
 )

--- a/core/core-api/src/main/java/io/dodn/springboot/common/dto/CustomPageResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/dto/CustomPageResponse.java
@@ -1,0 +1,72 @@
+package io.dodn.springboot.common.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public class CustomPageResponse<T> {
+    private final List<T> content;          // 데이터 목록
+    private final int pageNumber;           // 현재 페이지 번호 (0부터 시작)
+    private final int pageSize;             // 페이지 크기
+    private final long totalElements;       // 전체 데이터 개수
+    private final int totalPages;           // 전체 페이지 수
+    private final boolean isLast;           // 마지막 페이지 여부
+    private final boolean isFirst;          // 첫 페이지 여부
+    private final boolean hasNext;          // 다음 페이지 존재 여부
+    private final boolean hasPrevious;      // 이전 페이지 존재 여부
+    private final boolean isEmpty;          // 현재 페이지가 비어있는지 여부
+
+    // Page 객체를 받아서 CustomPageResponse 객체로 변환하는 생성자
+    public CustomPageResponse(Page<T> page) {
+        this.content = page.getContent();
+        this.pageNumber = page.getNumber();
+        this.pageSize = page.getSize();
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+        this.isLast = page.isLast();
+        this.isFirst = page.isFirst();
+        this.hasNext = page.hasNext();
+        this.hasPrevious = page.hasPrevious();
+        this.isEmpty = page.isEmpty();
+    }
+
+    public List<T> getContent() {
+        return content;
+    }
+
+    public int getPageNumber() {
+        return pageNumber;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public long getTotalElements() {
+        return totalElements;
+    }
+
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    public boolean isLast() {
+        return isLast;
+    }
+
+    public boolean isFirst() {
+        return isFirst;
+    }
+
+    public boolean isHasNext() {
+        return hasNext;
+    }
+
+    public boolean isHasPrevious() {
+        return hasPrevious;
+    }
+
+    public boolean isEmpty() {
+        return isEmpty;
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/common/support/ApiControllerAdvice.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/support/ApiControllerAdvice.java
@@ -3,6 +3,7 @@ package io.dodn.springboot.common.support;
 import io.dodn.springboot.common.support.error.CoreException;
 import io.dodn.springboot.common.support.error.ErrorType;
 import io.dodn.springboot.common.support.response.ApiResponse;
+import io.dodn.springboot.matzip.exception.NotFoundPlaceException;
 import io.dodn.springboot.member.exception.NotFoundMemberException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,6 +62,18 @@ public class ApiControllerAdvice {
     public ResponseEntity<ApiResponse<?>> handleAuthorizationDeniedException(AuthorizationDeniedException e) {
         log.warn("AuthorizationDeniedException : {}", e.getMessage());
         return new ResponseEntity<>(ApiResponse.error(ErrorType.AUTHORIZATION_DENIED), ErrorType.AUTHORIZATION_DENIED.getStatus());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("IllegalArgumentException : {}", e.getMessage());
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.ERR_1004), ErrorType.ERR_1004.getStatus());
+    }
+
+    @ExceptionHandler(NotFoundPlaceException.class)
+    public ResponseEntity<ApiResponse<?>> handleNotFoundPlaceException(NotFoundPlaceException e) {
+        log.warn("NotFoundPlaceException : {}", e.getMessage());
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.ERR_1005), ErrorType.ERR_1005.getStatus());
     }
 
 

--- a/core/core-api/src/main/java/io/dodn/springboot/common/support/ApiControllerAdvice.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/support/ApiControllerAdvice.java
@@ -6,7 +6,6 @@ import io.dodn.springboot.common.support.response.ApiResponse;
 import io.dodn.springboot.member.exception.NotFoundMemberException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -32,13 +31,13 @@ public class ApiControllerAdvice {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
         log.error("Exception : {}", e.getMessage(), e);
-        return new ResponseEntity<>(ApiResponse.error(ErrorType.DEFAULT_ERROR), ErrorType.DEFAULT_ERROR.getStatus());
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.ERR_1099), ErrorType.ERR_1099.getStatus());
     }
 
     @ExceptionHandler(NotFoundMemberException.class)
     public ResponseEntity<ApiResponse<?>> handleNotFoundMemberException(NotFoundMemberException e) {
         log.warn("NotFoundMemberException : {}", e.getMessage(), e); // 스택 트레이스 없이 메시지만 로깅
-        return new ResponseEntity<>(ApiResponse.error(ErrorType.NOT_FOUND_MEMBER, e.getMessage()), ErrorType.NOT_FOUND_MEMBER.getStatus());
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.ERR_1001, e.getMessage()), ErrorType.ERR_1001.getStatus());
     }
 
     // Spring @Valid 유효성 검사 실패 시 (MethodArgumentNotValidException)
@@ -47,7 +46,7 @@ public class ApiControllerAdvice {
         log.warn("MethodArgumentNotValidException : {}", e.getMessage()); // 보통 필드별 오류 메시지가 e.getBindingResult()에 있음
         // ErrorType에 VALIDATION_FAILED 와 같은 타입을 정의하고 사용
         // e.getBindingResult()를 파싱하여 더 상세한 오류 메시지를 ApiResponse에 담을 수도 있습니다.
-        return new ResponseEntity<>(ApiResponse.error(ErrorType.INVALID_INPUT_VALUE, e.getBindingResult().getAllErrors().get(0).getDefaultMessage()), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.INVALID_INPUT_VALUE, e.getBindingResult().getAllErrors().get(0).getDefaultMessage()), ErrorType.INVALID_INPUT_VALUE.getStatus());
     }
 
     // 필수 요청 파라미터 누락 시 (MissingServletRequestParameterException)
@@ -55,13 +54,13 @@ public class ApiControllerAdvice {
     public ResponseEntity<ApiResponse<?>> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
         log.warn("MissingServletRequestParameterException : {}", e.getMessage());
         // ErrorType에 REQUIRED_PARAMETER_MISSING 과 같은 타입을 정의하고 사용
-        return new ResponseEntity<>(ApiResponse.error(ErrorType.MISSING_REQUEST_PARAMETER, e.getParameterName() + " 파라미터가 필요합니다."), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.MISSING_REQUEST_PARAMETER, e.getParameterName() + " 파라미터가 필요합니다."), ErrorType.MISSING_REQUEST_PARAMETER.getStatus());
     }
 
     @ExceptionHandler(AuthorizationDeniedException.class)
     public ResponseEntity<ApiResponse<?>> handleAuthorizationDeniedException(AuthorizationDeniedException e) {
         log.warn("AuthorizationDeniedException : {}", e.getMessage());
-        return new ResponseEntity<>(ApiResponse.error(ErrorType.AUTHORIZATION_DENIED), HttpStatus.FORBIDDEN);
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.AUTHORIZATION_DENIED), ErrorType.AUTHORIZATION_DENIED.getStatus());
     }
 
 

--- a/core/core-api/src/main/java/io/dodn/springboot/common/support/error/ErrorType.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/support/error/ErrorType.java
@@ -14,6 +14,8 @@ public enum ErrorType {
     ERR_1001(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "등록되지 않은 사용자", LogLevel.ERROR),
     ERR_1002(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "필수 항목 동의 누락", LogLevel.ERROR),
     ERR_1003(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "휴대전화 번호 존재하지않음", LogLevel.ERROR),
+    ERR_1004(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST, "올바른 요청이 아닙니다.", LogLevel.ERROR),
+    ERR_1005(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "존재하지 않는 공간입니다", LogLevel.ERROR),
     ERR_1099(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.", LogLevel.ERROR);
 
 

--- a/core/core-api/src/main/java/io/dodn/springboot/common/support/error/ErrorType.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/support/error/ErrorType.java
@@ -6,12 +6,15 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
 
     FAILED_KAKAO(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "Failed to retrieve Kakao token.", LogLevel.ERROR),
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_INPUT_VALUE,"입력값이 올바르지 않습니다.", LogLevel.WARN),
-    MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST,"필수 요청 파라미터가 누락되었습니다.", LogLevel.WARN),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_INPUT_VALUE, "입력값이 올바르지 않습니다.", LogLevel.WARN),
+    MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST, "필수 요청 파라미터가 누락되었습니다.", LogLevel.WARN),
     AUTHORIZATION_DENIED(HttpStatus.FORBIDDEN, ErrorCode.FORBIDDEN, "접근 권한이 없습니다.", LogLevel.WARN),
-    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "가입되지 않은 사용자 입니다.", LogLevel.INFO),
-    OAUTH_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, ErrorCode.UNAUTHORIZED,"OAuth2 로그인에 실패했습니다.", LogLevel.WARN),
-    DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR,"서버 내부 오류가 발생했습니다.", LogLevel.ERROR);
+    OAUTH_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, ErrorCode.UNAUTHORIZED, "OAuth2 로그인에 실패했습니다.", LogLevel.WARN),
+
+    ERR_1001(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "등록되지 않은 사용자", LogLevel.ERROR),
+    ERR_1002(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "필수 항목 동의 누락", LogLevel.ERROR),
+    ERR_1003(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "휴대전화 번호 존재하지않음", LogLevel.ERROR),
+    ERR_1099(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.", LogLevel.ERROR);
 
 
     private final HttpStatus status;

--- a/core/core-api/src/main/java/io/dodn/springboot/common/support/error/ErrorType.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/support/error/ErrorType.java
@@ -16,6 +16,7 @@ public enum ErrorType {
     ERR_1003(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "휴대전화 번호 존재하지않음", LogLevel.ERROR),
     ERR_1004(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST, "올바른 요청이 아닙니다.", LogLevel.ERROR),
     ERR_1005(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "존재하지 않는 공간입니다", LogLevel.ERROR),
+    ERR_1006(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST, "이미 쪽지를 보냈습니다.", LogLevel.ERROR),
     ERR_1099(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.", LogLevel.ERROR);
 
 

--- a/core/core-api/src/main/java/io/dodn/springboot/common/support/error/ErrorType.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/support/error/ErrorType.java
@@ -17,6 +17,8 @@ public enum ErrorType {
     ERR_1004(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST, "올바른 요청이 아닙니다.", LogLevel.ERROR),
     ERR_1005(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND, "존재하지 않는 공간입니다", LogLevel.ERROR),
     ERR_1006(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST, "이미 쪽지를 보냈습니다.", LogLevel.ERROR),
+    ERR_1007(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST, "파일이 비어있습니다.", LogLevel.ERROR),
+    ERR_1008(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR, "데이터 삽입중 오류가 발생했습니다.", LogLevel.ERROR),
     ERR_1099(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.", LogLevel.ERROR);
 
 

--- a/core/core-api/src/main/java/io/dodn/springboot/common/support/error/ErrorType.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/support/error/ErrorType.java
@@ -19,6 +19,8 @@ public enum ErrorType {
     ERR_1006(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST, "이미 쪽지를 보냈습니다.", LogLevel.ERROR),
     ERR_1007(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST, "파일이 비어있습니다.", LogLevel.ERROR),
     ERR_1008(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR, "데이터 삽입중 오류가 발생했습니다.", LogLevel.ERROR),
+    ERR_1009(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR, "리프레시 토큰이 만료되었습니다.", LogLevel.ERROR),
+    ERR_1010(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR, "유효하지 않은 리프레시 토큰.", LogLevel.ERROR),
     ERR_1099(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.", LogLevel.ERROR);
 
 

--- a/core/core-api/src/main/java/io/dodn/springboot/common/support/response/ApiResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/support/response/ApiResponse.java
@@ -17,7 +17,7 @@ public class ApiResponse<S> {
         this.error = error;
     }
 
-    public static ApiResponse<?> success() {
+    public static ApiResponse<Void> success() {
         return new ApiResponse<>(ResultType.SUCCESS, null, null);
     }
 

--- a/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MatzipDocs.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MatzipDocs.java
@@ -44,7 +44,7 @@ public interface MatzipDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
                     content = @Content(schema = @Schema(implementation = Page.class))) // NearbyPlaceResponse를 감싸는 Page
     })
-    ApiResponse<Page<NearbyPlaceResponse>> findNearbyPlaces(
+    public ApiResponse<CustomPageResponse<NearbyPlaceResponse>> findNearbyPlaces(
             @Parameter(name = "lat", description = "현재 위치의 위도", required = true, example = "37.53313") @RequestParam("lat") double latitude,
             @Parameter(name = "lon", description = "현재 위치의 경도", required = true, example = "126.904091") @RequestParam("lon") double longitude,
             @Parameter(name = "radius", description = "검색 반경(미터 단위)", example = "1000") @RequestParam(value = "radius", defaultValue = "1000") int radius,

--- a/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MatzipDocs.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MatzipDocs.java
@@ -8,6 +8,7 @@ import io.dodn.springboot.matzip.controller.response.NearbyPlaceResponse;
 import io.dodn.springboot.matzip.controller.response.PlaceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -44,12 +45,20 @@ public interface MatzipDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
                     content = @Content(schema = @Schema(implementation = Page.class))) // NearbyPlaceResponse를 감싸는 Page
     })
+    @Parameters({
+            @Parameter(name = "page", description = "조회할 페이지 번호 (0부터 시작)", example = "0", schema = @Schema(type = "integer", defaultValue = "0")),
+            @Parameter(name = "size", description = "한 페이지에 보여줄 데이터 개수", example = "10", schema = @Schema(type = "integer", defaultValue = "10")),
+            @Parameter(name = "sort", description = "정렬 기준 - 형식: '속성명,정렬방향'. (예: likeCount,desc)",
+                    example = "likeCount,desc", schema = @Schema(type = "string"))
+    })
     public ApiResponse<CustomPageResponse<NearbyPlaceResponse>> findNearbyPlaces(
             @Parameter(name = "lat", description = "현재 위치의 위도", required = true, example = "37.53313") @RequestParam("lat") double latitude,
             @Parameter(name = "lon", description = "현재 위치의 경도", required = true, example = "126.904091") @RequestParam("lon") double longitude,
             @Parameter(name = "radius", description = "검색 반경(미터 단위)", example = "1000") @RequestParam(value = "radius", defaultValue = "1000") int radius,
             @Parameter(hidden = true) Pageable pageable // Pageable은 Swagger에서 자동으로 파라미터들을 생성해줍니다.
     );
+
+
 }
 
 

--- a/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MatzipDocs.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MatzipDocs.java
@@ -1,0 +1,58 @@
+package io.dodn.springboot.common.swagger;
+
+import io.dodn.springboot.common.annotation.LoginUser;
+import io.dodn.springboot.common.dto.CustomPageResponse;
+import io.dodn.springboot.common.support.response.ApiResponse;
+import io.dodn.springboot.matzip.controller.response.LikeToggleResponse;
+import io.dodn.springboot.matzip.controller.response.NearbyPlaceResponse;
+import io.dodn.springboot.matzip.controller.response.PlaceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface MatzipDocs {
+    @Operation(summary = "모든 맛집 목록 조회", description = "등록된 모든 맛집의 목록을 페이지네이션하여 조회합니다. 로그인 시 좋아요 여부도 함께 반환합니다.", tags = { "Matzip Management" })
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = CustomPageResponse.class))) // PlaceResponse를 감싸는 CustomPageResponse
+    })
+    ApiResponse<CustomPageResponse<PlaceResponse>> getAllPlaces(
+            @Parameter(hidden = true) @LoginUser final Long memberId,
+            @Parameter(hidden = true) Pageable pageable
+    );
+
+    @Operation(summary = "맛집 좋아요 토글", description = "특정 맛집에 대한 사용자의 좋아요 상태를 토글합니다. (좋아요/좋아요 취소)", tags = { "Matzip Management" })
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = LikeToggleResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "맛집 또는 회원이 존재하지 않음")
+    })
+    ApiResponse<LikeToggleResponse> toggleLikePlace(
+            @Parameter(hidden = true) @LoginUser final Long memberId,
+            @Parameter(name = "placeId", description = "좋아요를 토글할 맛집의 ID", required = true, in = ParameterIn.PATH) @PathVariable("placeId") final Long placeId
+    );
+
+    @Operation(summary = "주변 맛집 검색", description = "주어진 위도, 경도, 반경 내의 맛집들을 검색하여 페이지네이션 결과로 반환합니다.", tags = { "Matzip Management" })
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = Page.class))) // NearbyPlaceResponse를 감싸는 Page
+    })
+    ApiResponse<Page<NearbyPlaceResponse>> findNearbyPlaces(
+            @Parameter(name = "lat", description = "현재 위치의 위도", required = true, example = "37.53313") @RequestParam("lat") double latitude,
+            @Parameter(name = "lon", description = "현재 위치의 경도", required = true, example = "126.904091") @RequestParam("lon") double longitude,
+            @Parameter(name = "radius", description = "검색 반경(미터 단위)", example = "1000") @RequestParam(value = "radius", defaultValue = "1000") int radius,
+            @Parameter(hidden = true) Pageable pageable // Pageable은 Swagger에서 자동으로 파라미터들을 생성해줍니다.
+    );
+}
+
+
+
+
+

--- a/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MemberDocs.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MemberDocs.java
@@ -1,48 +1,74 @@
 package io.dodn.springboot.common.swagger;
 
 import io.dodn.springboot.common.annotation.LoginUser;
+import io.dodn.springboot.common.support.response.ApiResponse;
 import io.dodn.springboot.member.controller.request.UpdateMemberRequest;
 import io.dodn.springboot.member.controller.response.MemberResponse;
 import io.dodn.springboot.member.controller.response.MembersResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 public interface MemberDocs {
 
-    @Operation(summary = "회원 정보 조회", description = "특정 회원의 정보를 조회하는 엔드포인트입니다.", tags = { "Member Management" })
-    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않음") })
-    io.dodn.springboot.common.support.response.ApiResponse<MemberResponse> getMemberById(@LoginUser Long memberId);
+    @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.", tags = { "Member Management" })
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = MemberResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원이 존재하지 않음")
+    })
+    ApiResponse<MemberResponse> getMemberById(
+            @Parameter(hidden = true) @LoginUser Long memberId
+    );
 
-    @Operation(summary = "팀과 함께 회원 목록 조회", description = "현재 등록된 회원의 목록을 팀 정보와 함께 조회하는 엔드포인트입니다.", tags = { "Member Management" })
-    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않음") })
-    io.dodn.springboot.common.support.response.ApiResponse<MembersResponse> getMembersWithTeam();
+    @Operation(summary = "모든 회원 및 팀 정보 조회 (Fetch Join)", description = "모든 회원의 목록을 팀 정보와 함께 Fetch Join하여 조회합니다.", tags = { "Member Management" })
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = MembersResponse.class)))
+    })
+    ApiResponse<MembersResponse> getMembersWithTeam();
 
-    @Operation(summary = "팀별 회원 목록 조회", description = "특정 팀에 속한 회원들의 목록을 조회하는 엔드포인트입니다.", tags = { "Member Management" })
-    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "404", description = "팀이 존재하지 않음") })
-    io.dodn.springboot.common.support.response.ApiResponse<MembersResponse> getMemberByTeam(
-            @RequestParam("teamId") final Long teamId);
+    @Operation(summary = "전체 회원 수 조회", description = "등록된 모든 회원의 수를 조회합니다.", tags = { "Member Management" })
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = Long.class)))
+    })
+    ApiResponse<Long> getMemberCount();
 
-    @Operation(summary = "회원 수 조회", description = "현재 등록된 회원의 수를 조회하는 엔드포인트입니다.", tags = { "Member Management" })
-    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않음") })
-    io.dodn.springboot.common.support.response.ApiResponse<Long> getMemberCount();
+    @Operation(summary = "특정 팀 소속 회원 목록 조회", description = "지정된 팀 ID에 속한 모든 회원의 목록을 조회합니다.", tags = { "Member Management" })
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = MembersResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "팀 또는 해당 팀의 회원이 존재하지 않음")
+    })
+    ApiResponse<MembersResponse> getMemberByTeam(
+            @Parameter(name = "teamId", description = "조회할 팀의 ID", required = true, in = ParameterIn.QUERY, example = "1") @RequestParam("teamId") final Long teamId
+    );
 
-    @Operation(summary = "회원 정보 수정", description = "특정 회원의 정보를 수정하는 엔드포인트입니다.", tags = { "Member Management" })
-    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않음") })
-    io.dodn.springboot.common.support.response.ApiResponse<MemberResponse> updateMember(
-            @PathVariable("memberId") final Long memberId,
+    @Operation(summary = "내 정보 수정", description = "현재 로그인된 사용자의 정보를 수정합니다.", tags = { "Member Management" })
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = MemberResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원이 존재하지 않음")
+    })
+    ApiResponse<MemberResponse> updateMember(
+            @Parameter(hidden = true) @LoginUser final Long memberId,
             @RequestBody UpdateMemberRequest updateMemberRequest
     );
 
-
-    @Operation(summary = "권한 테스트용", description = "권한 테스트 엔드포인트입니다.", tags = { "Member Management" })
-    io.dodn.springboot.common.support.response.ApiResponse<String> getTest();
+    @Operation(summary = "관리자 권한 테스트", description = "관리자(ADMIN) 역할이 있는 사용자만 접근 가능한 테스트 엔드포인트입니다.", tags = { "Member Management" })
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음")
+    })
+    ApiResponse<String> getTest();
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MemberDocs.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MemberDocs.java
@@ -3,6 +3,7 @@ package io.dodn.springboot.common.swagger;
 import io.dodn.springboot.common.annotation.LoginUser;
 import io.dodn.springboot.common.support.response.ApiResponse;
 import io.dodn.springboot.member.controller.request.UpdateMemberRequest;
+import io.dodn.springboot.member.controller.response.ImageUrlResponse;
 import io.dodn.springboot.member.controller.response.MemberResponse;
 import io.dodn.springboot.member.controller.response.MembersResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 public interface MemberDocs {
 
@@ -71,4 +74,11 @@ public interface MemberDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음")
     })
     ApiResponse<String> getTest();
+
+
+    @Operation(summary = "메인 이미지 URL 조회", description = "메인페이지에서 이미지 사용하기위한 엔드포인트.", tags = { "Member Management" })
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
+    })
+    public ApiResponse<List<ImageUrlResponse>> getMemberUrls();
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MemberDocs.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/swagger/MemberDocs.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -26,7 +27,7 @@ public interface MemberDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원이 존재하지 않음")
     })
-    ApiResponse<MemberResponse> getMemberById(
+    ApiResponse<MemberResponse> getMemberByIdMe(
             @Parameter(hidden = true) @LoginUser Long memberId
     );
 
@@ -81,4 +82,16 @@ public interface MemberDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
     })
     public ApiResponse<List<ImageUrlResponse>> getMemberUrls();
+
+
+    @Operation(summary = "멤버 정보 조회", description = "memberId 에 해당하는 사용자의 정보를 조회합니다.", tags = { "Member Management" })
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = MemberResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원이 존재하지 않음")
+    })
+    public ApiResponse<MemberResponse> getMemberById(
+            @PathVariable("memberId") final Long memberId
+    );
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/common/swagger/PlaneDocs.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/common/swagger/PlaneDocs.java
@@ -1,11 +1,17 @@
 package io.dodn.springboot.common.swagger;
 
+import io.dodn.springboot.common.annotation.LoginUser;
 import io.dodn.springboot.plane.controller.request.SendMessageRequest;
+import io.dodn.springboot.plane.controller.response.MessageResponse;
 import io.dodn.springboot.plane.controller.response.SendMessageResponse;
+import io.dodn.springboot.plane.controller.response.TodayMessageResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
 
 public interface PlaneDocs {
     @Operation(summary = "쪽지 발송", description = "특정 회원에게 쪽지를 발송하는 엔드포인트입니다.", tags = { "Plane Management" })
@@ -15,12 +21,15 @@ public interface PlaneDocs {
             @RequestBody SendMessageRequest request
     );
 
-    @Operation(summary = "쪽지 읽음 처리", description = "특정 회원이 쪽지를 읽음 처리하는 엔드포인트입니다.", tags = { "Plane Management" })
-    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "404", description = "쪽지가 존재하지 않음") })
-    io.dodn.springboot.common.support.response.ApiResponse<?> readMessage(
-            @RequestBody io.dodn.springboot.plane.controller.request.ReadMessageRequest request
+    @Operation(summary = "쪽지 조회", description = "특정 회원이 쪽지를 조회하는 엔드포인트입니다.", tags = { "Plane Management" })
+    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "성공")})
+    public io.dodn.springboot.common.support.response.ApiResponse<List<MessageResponse>> readMessage(
+            @Parameter(hidden = true) @LoginUser long readerId
     );
 
-
-    }
+    @Operation(summary = "쪽지 존재 여부", description = "오늘 받은 편지 존재 여부 API (팝업 알림용).", tags = { "Plane Management" })
+    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "성공")})
+    public io.dodn.springboot.common.support.response.ApiResponse<TodayMessageResponse> getTodayMessage(
+            @Parameter(hidden = true) @LoginUser long readerId
+    );
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/core/controller/ExampleController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/core/controller/ExampleController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Deprecated
 @RestController
 public class ExampleController {
 

--- a/core/core-api/src/main/java/io/dodn/springboot/event/controller/EventController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/event/controller/EventController.java
@@ -1,0 +1,36 @@
+package io.dodn.springboot.event.controller;
+
+import io.dodn.springboot.common.support.response.ApiResponse;
+import io.dodn.springboot.event.controller.response.CalendarEventResponse;
+import io.dodn.springboot.event.domain.EventService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/event")
+public class EventController {
+    private final EventService eventService;
+
+    public EventController(final EventService eventService) {
+        this.eventService = eventService;
+    }
+
+    @GetMapping("/monthly")
+    public ApiResponse<List<CalendarEventResponse>> getMonthlyCalendar(
+            @RequestParam(value = "year", required = false) Integer year,
+            @RequestParam(value = "month", required = false) Integer month
+    ) {
+        LocalDate today = LocalDate.now();
+        int queryYear = (year != null) ? year : today.getYear();
+        int queryMonth = (month != null) ? month : today.getMonthValue();
+
+        List<CalendarEventResponse> monthlyEvents = eventService.getMonthlyEvents(queryYear, queryMonth);
+        return ApiResponse.success(monthlyEvents);
+    }
+
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/event/controller/response/CalendarEventResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/event/controller/response/CalendarEventResponse.java
@@ -38,7 +38,7 @@ public record CalendarEventResponse(
 
         return new CalendarEventResponse(
                 null, // 생일은 Event 테이블에 ID가 없으므로 null
-                EventCategory.BIRTHDAY.getDescription(),
+                EventCategory.BIRTHDAY.name(),
                 member.getName(),
                 birthdayStart,
                 birthdayEnd

--- a/core/core-api/src/main/java/io/dodn/springboot/event/controller/response/CalendarEventResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/event/controller/response/CalendarEventResponse.java
@@ -13,8 +13,7 @@ public record CalendarEventResponse(
         String eventType,
         String title,
         LocalDateTime start,
-        LocalDateTime end,
-        String creatorName
+        LocalDateTime end
 ) {
 
     public static CalendarEventResponse fromEvent(Event event) {
@@ -23,8 +22,7 @@ public record CalendarEventResponse(
                 event.getEventCategory().name(), // Enum의 이름을 문자열로 사용
                 event.getTitle(),
                 event.getStartDatetime(),
-                event.getEndDatetime(),
-                event.getCreator().getName() // Member 엔티티에 getName()이 있다고 가정
+                event.getEndDatetime()
         );
     }
 
@@ -41,10 +39,9 @@ public record CalendarEventResponse(
         return new CalendarEventResponse(
                 null, // 생일은 Event 테이블에 ID가 없으므로 null
                 EventCategory.BIRTHDAY.getDescription(),
-                member.getName() + "님 생일이에요",
+                member.getName(),
                 birthdayStart,
-                birthdayEnd,
-                null // 생성자가 없으므로 null
+                birthdayEnd
         );
     }
 

--- a/core/core-api/src/main/java/io/dodn/springboot/event/controller/response/CalendarEventResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/event/controller/response/CalendarEventResponse.java
@@ -1,0 +1,52 @@
+package io.dodn.springboot.event.controller.response;
+
+import io.dodn.springboot.storage.db.common.entity.EventCategory;
+import io.dodn.springboot.storage.db.event.entity.Event;
+import io.dodn.springboot.storage.db.member.entity.Member;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.MonthDay;
+
+public record CalendarEventResponse(
+        Long eventId,
+        String eventType,
+        String title,
+        LocalDateTime start,
+        LocalDateTime end,
+        String creatorName
+) {
+
+    public static CalendarEventResponse fromEvent(Event event) {
+        return new CalendarEventResponse(
+                event.getId(),
+                event.getEventCategory().name(), // Enum의 이름을 문자열로 사용
+                event.getTitle(),
+                event.getStartDatetime(),
+                event.getEndDatetime(),
+                event.getCreator().getName() // Member 엔티티에 getName()이 있다고 가정
+        );
+    }
+
+    public static CalendarEventResponse fromBirthday(Member member, int year) {
+        // 생일은 하루 종일 지속되는 이벤트로 처리
+        MonthDay birthdayMonthDay = MonthDay.parse("--" + member.getBirthday());
+
+        LocalDate birthdayThisYear = birthdayMonthDay.atYear(year);
+
+        // 생일은 하루 종일 지속되는 이벤트로 처리
+        LocalDateTime birthdayStart = birthdayThisYear.atStartOfDay();
+        LocalDateTime birthdayEnd = birthdayStart.plusDays(1).minusNanos(1);
+
+        return new CalendarEventResponse(
+                null, // 생일은 Event 테이블에 ID가 없으므로 null
+                EventCategory.BIRTHDAY.getDescription(),
+                member.getName() + "님 생일이에요",
+                birthdayStart,
+                birthdayEnd,
+                null // 생성자가 없으므로 null
+        );
+    }
+
+
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/event/domain/EventService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/event/domain/EventService.java
@@ -1,0 +1,52 @@
+package io.dodn.springboot.event.domain;
+
+import io.dodn.springboot.event.controller.response.CalendarEventResponse;
+import io.dodn.springboot.storage.db.event.EventRepository;
+import io.dodn.springboot.storage.db.event.entity.Event;
+import io.dodn.springboot.storage.db.member.MemberRepository;
+import io.dodn.springboot.storage.db.member.entity.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Service
+public class EventService {
+    private final EventRepository eventRepository;
+    private final MemberRepository memberRepository;
+
+    public EventService(final EventRepository eventRepository, final MemberRepository memberRepository) {
+        this.eventRepository = eventRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<CalendarEventResponse> getMonthlyEvents(
+            final int year,
+            final int month
+    ) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDateTime startDate = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime endDate = yearMonth.atEndOfMonth().plusDays(1).atStartOfDay();
+
+        List<Event> regularEvents = eventRepository.findEventsForPeriod(startDate, endDate);
+
+        // ★★★ 월(int)을 두 자리 문자열(예: "06")로 포맷팅하여 전달 ★★★
+        String monthString = String.format("%02d", month);
+        List<Member> birthdayMembers = memberRepository.findMembersWithBirthdayInMonth(monthString);
+
+        Stream<CalendarEventResponse> regularEventStream = regularEvents.stream()
+                .map(CalendarEventResponse::fromEvent);
+
+        Stream<CalendarEventResponse> birthdayEventStream = birthdayMembers.stream()
+                .map(member -> CalendarEventResponse.fromBirthday(member, year));
+
+        return Stream.concat(regularEventStream, birthdayEventStream)
+                .sorted(Comparator.comparing(CalendarEventResponse::start))
+                .toList();
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/event/domain/EventService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/event/domain/EventService.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.YearMonth;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -31,7 +30,7 @@ public class EventService {
     ) {
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDateTime startDate = yearMonth.atDay(1).atStartOfDay();
-        LocalDateTime endDate = yearMonth.atEndOfMonth().plusDays(1).atStartOfDay();
+        LocalDateTime endDate = yearMonth.atEndOfMonth().plusDays(1).atStartOfDay().minusDays(1);
 
         List<Event> regularEvents = eventRepository.findEventsForPeriod(startDate, endDate);
 
@@ -45,8 +44,7 @@ public class EventService {
         Stream<CalendarEventResponse> birthdayEventStream = birthdayMembers.stream()
                 .map(member -> CalendarEventResponse.fromBirthday(member, year));
 
-        return Stream.concat(regularEventStream, birthdayEventStream)
-                .sorted(Comparator.comparing(CalendarEventResponse::start))
+        return Stream.concat(birthdayEventStream, regularEventStream)
                 .toList();
     }
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
@@ -1,6 +1,7 @@
 package io.dodn.springboot.matzip.controller;
 
 import io.dodn.springboot.common.annotation.LoginUser;
+import io.dodn.springboot.common.dto.CustomPageResponse;
 import io.dodn.springboot.common.support.response.ApiResponse;
 import io.dodn.springboot.matzip.controller.response.PlaceResponse;
 import io.dodn.springboot.matzip.domain.MatzipService;
@@ -21,12 +22,13 @@ public class MatzipController {
     }
 
     @GetMapping("/places")
-    public ApiResponse<Page<PlaceResponse>> getAllPlaces(
-            // 로그인한 사용자 ID를 받습니다. 비로그인 시 null이 전달되도록 ArgumentResolver 설정 필요
+    public ApiResponse<CustomPageResponse<PlaceResponse>> getAllPlaces(
             @Parameter(hidden = true) @LoginUser final Long memberId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Page<PlaceResponse> placeResponses = matzipService.findAllPlaces(memberId, pageable);
-        return ApiResponse.success(placeResponses);
+
+        CustomPageResponse<PlaceResponse> response = new CustomPageResponse<>(placeResponses);
+        return ApiResponse.success(response);
     }
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
@@ -4,6 +4,7 @@ import io.dodn.springboot.common.annotation.LoginUser;
 import io.dodn.springboot.common.support.response.ApiResponse;
 import io.dodn.springboot.matzip.controller.response.PlaceResponse;
 import io.dodn.springboot.matzip.domain.MatzipService;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -22,7 +23,7 @@ public class MatzipController {
     @GetMapping("/places")
     public ApiResponse<Page<PlaceResponse>> getAllPlaces(
             // ★ 로그인한 사용자 ID를 받습니다. 비로그인 시 null이 전달되도록 ArgumentResolver 설정 필요
-            @LoginUser final Long memberId,
+            @Parameter(hidden = true) @LoginUser final Long memberId,
             // ★ 페이지네이션 정보를 받습니다. 예: /api/v1/places?page=0&size=10&sort=createdAt,desc
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
@@ -3,6 +3,7 @@ package io.dodn.springboot.matzip.controller;
 import io.dodn.springboot.common.annotation.LoginUser;
 import io.dodn.springboot.common.dto.CustomPageResponse;
 import io.dodn.springboot.common.support.response.ApiResponse;
+import io.dodn.springboot.matzip.controller.response.LikeToggleResponse;
 import io.dodn.springboot.matzip.controller.response.PlaceResponse;
 import io.dodn.springboot.matzip.domain.MatzipService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,6 +12,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -31,4 +34,14 @@ public class MatzipController {
         CustomPageResponse<PlaceResponse> response = new CustomPageResponse<>(placeResponses);
         return ApiResponse.success(response);
     }
+
+    @PostMapping("/toggle/like/{placeId}")
+    public ApiResponse<LikeToggleResponse> toggleLikePlace(
+            @Parameter(hidden = true) @LoginUser final Long memberId,
+            @PathVariable("placeId") final Long placeId
+    ) {
+        final LikeToggleResponse likeToggleResponse = matzipService.toggleLike(memberId, placeId);
+        return ApiResponse.success(likeToggleResponse);
+    }
+
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
@@ -4,9 +4,12 @@ import io.dodn.springboot.common.annotation.LoginUser;
 import io.dodn.springboot.common.dto.CustomPageResponse;
 import io.dodn.springboot.common.support.response.ApiResponse;
 import io.dodn.springboot.matzip.controller.response.LikeToggleResponse;
+import io.dodn.springboot.matzip.controller.response.NearbyPlaceResponse;
 import io.dodn.springboot.matzip.controller.response.PlaceResponse;
 import io.dodn.springboot.matzip.domain.MatzipService;
 import io.swagger.v3.oas.annotations.Parameter;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -14,20 +17,25 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/v1/matzip")
 public class MatzipController {
     private final MatzipService matzipService;
+    private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326); // SRID 4326 (WGS84) 사용
 
     public MatzipController(final MatzipService matzipService) {
         this.matzipService = matzipService;
     }
 
+
     @GetMapping("/places")
     public ApiResponse<CustomPageResponse<PlaceResponse>> getAllPlaces(
             @Parameter(hidden = true) @LoginUser final Long memberId,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Page<PlaceResponse> placeResponses = matzipService.findAllPlaces(memberId, pageable);
 
@@ -44,4 +52,14 @@ public class MatzipController {
         return ApiResponse.success(likeToggleResponse);
     }
 
+    @GetMapping("/nearby")
+    public ApiResponse<Page<NearbyPlaceResponse>> findNearbyPlaces(
+            @RequestParam("lat") double latitude,
+            @RequestParam("lon") double longitude,
+            @RequestParam(value = "radius", defaultValue = "1000") int radius, // 기본 반경 1km
+            Pageable pageable
+    ) {
+        Page<NearbyPlaceResponse> nearbyPlaces = matzipService.findNearbyPlaces(latitude, longitude, radius, pageable);
+        return ApiResponse.success(nearbyPlaces);
+    }
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
@@ -22,9 +22,8 @@ public class MatzipController {
 
     @GetMapping("/places")
     public ApiResponse<Page<PlaceResponse>> getAllPlaces(
-            // ★ 로그인한 사용자 ID를 받습니다. 비로그인 시 null이 전달되도록 ArgumentResolver 설정 필요
+            // 로그인한 사용자 ID를 받습니다. 비로그인 시 null이 전달되도록 ArgumentResolver 설정 필요
             @Parameter(hidden = true) @LoginUser final Long memberId,
-            // ★ 페이지네이션 정보를 받습니다. 예: /api/v1/places?page=0&size=10&sort=createdAt,desc
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Page<PlaceResponse> placeResponses = matzipService.findAllPlaces(memberId, pageable);

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
@@ -1,0 +1,32 @@
+package io.dodn.springboot.matzip.controller;
+
+import io.dodn.springboot.common.annotation.LoginUser;
+import io.dodn.springboot.common.support.response.ApiResponse;
+import io.dodn.springboot.matzip.controller.response.PlaceResponse;
+import io.dodn.springboot.matzip.domain.MatzipService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MatzipController {
+    private final MatzipService matzipService;
+
+    public MatzipController(final MatzipService matzipService) {
+        this.matzipService = matzipService;
+    }
+
+    @GetMapping("/places")
+    public ApiResponse<Page<PlaceResponse>> getAllPlaces(
+            // ★ 로그인한 사용자 ID를 받습니다. 비로그인 시 null이 전달되도록 ArgumentResolver 설정 필요
+            @LoginUser final Long memberId,
+            // ★ 페이지네이션 정보를 받습니다. 예: /api/v1/places?page=0&size=10&sort=createdAt,desc
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<PlaceResponse> placeResponses = matzipService.findAllPlaces(memberId, pageable);
+        return ApiResponse.success(placeResponses);
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
@@ -3,6 +3,7 @@ package io.dodn.springboot.matzip.controller;
 import io.dodn.springboot.common.annotation.LoginUser;
 import io.dodn.springboot.common.dto.CustomPageResponse;
 import io.dodn.springboot.common.support.response.ApiResponse;
+import io.dodn.springboot.common.swagger.MatzipDocs;
 import io.dodn.springboot.matzip.controller.response.LikeToggleResponse;
 import io.dodn.springboot.matzip.controller.response.NearbyPlaceResponse;
 import io.dodn.springboot.matzip.controller.response.PlaceResponse;
@@ -12,8 +13,6 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/matzip")
-public class MatzipController {
+public class MatzipController implements MatzipDocs {
     private final MatzipService matzipService;
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326); // SRID 4326 (WGS84) 사용
 
@@ -35,7 +34,7 @@ public class MatzipController {
     @GetMapping("/places")
     public ApiResponse<CustomPageResponse<PlaceResponse>> getAllPlaces(
             @Parameter(hidden = true) @LoginUser final Long memberId,
-            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+            Pageable pageable
     ) {
         Page<PlaceResponse> placeResponses = matzipService.findAllPlaces(memberId, pageable);
 

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/MatzipController.java
@@ -9,8 +9,6 @@ import io.dodn.springboot.matzip.controller.response.NearbyPlaceResponse;
 import io.dodn.springboot.matzip.controller.response.PlaceResponse;
 import io.dodn.springboot.matzip.domain.MatzipService;
 import io.swagger.v3.oas.annotations.Parameter;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,8 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/matzip")
 public class MatzipController implements MatzipDocs {
     private final MatzipService matzipService;
-    private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326); // SRID 4326 (WGS84) 사용
-
     public MatzipController(final MatzipService matzipService) {
         this.matzipService = matzipService;
     }
@@ -52,13 +48,16 @@ public class MatzipController implements MatzipDocs {
     }
 
     @GetMapping("/nearby")
-    public ApiResponse<Page<NearbyPlaceResponse>> findNearbyPlaces(
+    public ApiResponse<CustomPageResponse<NearbyPlaceResponse>> findNearbyPlaces(
             @RequestParam("lat") double latitude,
             @RequestParam("lon") double longitude,
             @RequestParam(value = "radius", defaultValue = "1000") int radius, // 기본 반경 1km
             Pageable pageable
     ) {
         Page<NearbyPlaceResponse> nearbyPlaces = matzipService.findNearbyPlaces(latitude, longitude, radius, pageable);
-        return ApiResponse.success(nearbyPlaces);
+
+        CustomPageResponse<NearbyPlaceResponse> response = new CustomPageResponse<>(nearbyPlaces);
+        return ApiResponse.success(response);
     }
+
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/LikeToggleResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/LikeToggleResponse.java
@@ -1,0 +1,7 @@
+package io.dodn.springboot.matzip.controller.response;
+
+public record LikeToggleResponse(
+        boolean isLiked, // 토글 후의 좋아요 상태
+        long likeCount   // 토글 후의 총 좋아요 개수
+) {
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/NearbyPlaceResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/NearbyPlaceResponse.java
@@ -1,0 +1,28 @@
+package io.dodn.springboot.matzip.controller.response;
+
+import io.dodn.springboot.storage.db.matzip.PlaceWithDistance;
+
+public record NearbyPlaceResponse(
+        Long placeId,
+        String name,
+        String address,
+        String phoneNumber,
+        String description,
+        double latitude,
+        double longitude,
+        Double distanceInMeters // ★ 내 위치로부터의 거리 (미터)
+) {
+    public static NearbyPlaceResponse fromProjection(PlaceWithDistance place) {
+        return new NearbyPlaceResponse(
+                place.getPlaceId(),
+                place.getName(),
+                place.getAddress(),
+                place.getPhoneNumber(),
+                place.getDescription(),
+                place.getLatitude(),
+                place.getLongitude(),
+                place.getDistance()
+        );
+
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/NearbyPlaceResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/NearbyPlaceResponse.java
@@ -8,6 +8,7 @@ public record NearbyPlaceResponse(
         String address,
         String phoneNumber,
         String description,
+        int likeCount,
         double latitude,
         double longitude,
         Double distanceInMeters // ★ 내 위치로부터의 거리 (미터)
@@ -19,6 +20,7 @@ public record NearbyPlaceResponse(
                 place.getAddress(),
                 place.getPhoneNumber(),
                 place.getDescription(),
+                place.getLikeCount(),
                 place.getLatitude(),
                 place.getLongitude(),
                 place.getDistance()

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/PlaceResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/PlaceResponse.java
@@ -1,0 +1,38 @@
+package io.dodn.springboot.matzip.controller.response;
+
+import io.dodn.springboot.storage.db.matzip.entity.Place;
+
+import java.math.BigDecimal;
+
+public record PlaceResponse(
+        Long placeId,
+        String name,
+        String address,
+        String phoneNumber,
+        String description,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        long likeCount, // 맛집의 총 좋아요 수
+        boolean isLiked // ★ 현재 로그인한 사용자의 좋아요 여부
+) {
+    /**
+     * Place 엔티티와 좋아요 여부(isLiked)를 받아서 PlaceResponse 레코드를 생성하는 정적 팩토리 메서드
+     * @param place Place 엔티티
+     * @param isLiked 현재 사용자의 좋아요 여부
+     * @return PlaceResponse 레코드 인스턴스
+     */
+    public static PlaceResponse of(Place place, boolean isLiked) {
+        return new PlaceResponse(
+                place.getId(),
+                place.getName(),
+                place.getAddress(),
+                place.getPhoneNumber(),
+                place.getDescription(),
+                place.getLatitude(),
+                place.getLongitude(),
+                place.getLikeCount(), // Place 엔티티에 getLikeCount() 메서드가 있다고 가정
+                isLiked
+        );
+    }
+
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/PlaceResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/PlaceResponse.java
@@ -1,7 +1,10 @@
 package io.dodn.springboot.matzip.controller.response;
 
+import io.dodn.springboot.storage.db.matzip.entity.Category;
 import io.dodn.springboot.storage.db.matzip.entity.Place;
 import org.locationtech.jts.geom.Point;
+
+import java.util.Set;
 
 public record PlaceResponse(
         Long placeId,
@@ -12,7 +15,8 @@ public record PlaceResponse(
         double latitude,
         double longitude,
         long likeCount, // 맛집의 총 좋아요 수
-        boolean isLiked // ★ 현재 로그인한 사용자의 좋아요 여부
+        boolean isLiked, // 현재 로그인한 사용자의 좋아요 여부
+        Set<Category> categories
 ) {
     /**
      * Place 엔티티와 좋아요 여부(isLiked)를 받아서 PlaceResponse 레코드를 생성하는 정적 팩토리 메서드
@@ -35,7 +39,8 @@ public record PlaceResponse(
                 pointX,
                 pointY,
                 place.getLikeCount(), // Place 엔티티에 getLikeCount() 메서드가 있다고 가정
-                isLiked
+                isLiked,
+                place.getCategories()
         );
     }
 

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/PlaceResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/controller/response/PlaceResponse.java
@@ -1,8 +1,7 @@
 package io.dodn.springboot.matzip.controller.response;
 
 import io.dodn.springboot.storage.db.matzip.entity.Place;
-
-import java.math.BigDecimal;
+import org.locationtech.jts.geom.Point;
 
 public record PlaceResponse(
         Long placeId,
@@ -10,8 +9,8 @@ public record PlaceResponse(
         String address,
         String phoneNumber,
         String description,
-        BigDecimal latitude,
-        BigDecimal longitude,
+        double latitude,
+        double longitude,
         long likeCount, // 맛집의 총 좋아요 수
         boolean isLiked // ★ 현재 로그인한 사용자의 좋아요 여부
 ) {
@@ -22,14 +21,19 @@ public record PlaceResponse(
      * @return PlaceResponse 레코드 인스턴스
      */
     public static PlaceResponse of(Place place, boolean isLiked) {
+        Point locationPoint = place.getLocation(); // 엔티티에서 Point 객체를 가져옴
+
+        final double pointX = locationPoint.getX();
+        final double pointY = locationPoint.getY();
+
         return new PlaceResponse(
                 place.getId(),
                 place.getName(),
                 place.getAddress(),
                 place.getPhoneNumber(),
                 place.getDescription(),
-                place.getLatitude(),
-                place.getLongitude(),
+                pointX,
+                pointY,
                 place.getLikeCount(), // Place 엔티티에 getLikeCount() 메서드가 있다고 가정
                 isLiked
         );

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/domain/MatzipService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/domain/MatzipService.java
@@ -35,9 +35,9 @@ public class MatzipService {
         Set<Long> likedPlaceIds = getLikedPlaceIds(memberId, placeList);
 
         // 3. Place 엔티티를 PlaceResponse DTO로 변환하면서, 좋아요 상태를 설정합니다.
-        return places.map(place -> {
-            return PlaceResponse.of(place, likedPlaceIds.contains(place.getId()));
-        });
+        return places.map(place ->
+                PlaceResponse.of(place, likedPlaceIds.contains(place.getId()))
+        );
     }
 
     private Set<Long> getLikedPlaceIds(final Long memberId, final List<Place> placeList) {

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/domain/MatzipService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/domain/MatzipService.java
@@ -1,8 +1,14 @@
 package io.dodn.springboot.matzip.domain;
 
+import io.dodn.springboot.matzip.controller.response.LikeToggleResponse;
 import io.dodn.springboot.matzip.controller.response.PlaceResponse;
+import io.dodn.springboot.matzip.exception.NotFoundPlaceException;
+import io.dodn.springboot.member.exception.NotFoundMemberException;
 import io.dodn.springboot.storage.db.matzip.MatzipRepository;
 import io.dodn.springboot.storage.db.matzip.entity.Place;
+import io.dodn.springboot.storage.db.matzip.entity.PlaceLike;
+import io.dodn.springboot.storage.db.member.MemberRepository;
+import io.dodn.springboot.storage.db.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -10,15 +16,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
 public class MatzipService {
     private final MatzipRepository matzipRepository;
+    private final MemberRepository memberRepository;
 
-    public MatzipService(final MatzipRepository matzipRepository) {
+    public MatzipService(final MatzipRepository matzipRepository, final MemberRepository memberRepository) {
         this.matzipRepository = matzipRepository;
+        this.memberRepository = memberRepository;
     }
 
     @Transactional(readOnly = true)
@@ -53,5 +62,32 @@ public class MatzipService {
 
         // 한 번의 쿼리로 현재 사용자가 좋아요를 누른 맛집 ID 목록을 가져옵니다.
         return matzipRepository.findLikedPlaceIdsByMemberAndPlaceIds(memberId, placeIds);
+    }
+
+    @Transactional
+    public LikeToggleResponse toggleLike(final Long memberId, final Long placeId) {
+        // 1. 기존 '좋아요' 기록이 있는지 확인합니다.
+        Optional<PlaceLike> existingLike = matzipRepository.findByMemberIdAndPlaceId(memberId, placeId);
+
+        Place place = matzipRepository.findByPlaceId(placeId)
+                .orElseThrow(() -> new NotFoundPlaceException("맛집을 찾을 수 없습니다."));
+
+        // 2. '좋아요' 기록이 있다면 -> 좋아요 취소 (삭제 및 카운트 감소)
+        if (existingLike.isPresent()) {
+            matzipRepository.delete(existingLike.get());
+            place.decreaseLikeCount();
+            return new LikeToggleResponse(false, place.getLikeCount()); // isLiked: false, 업데이트된 카운트
+        }
+        // 3. '좋아요' 기록이 없다면 -> 좋아요 처리 (삽입 및 카운트 증가)
+        else {
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new NotFoundMemberException("사용자를 찾을 수 없습니다."));
+
+            PlaceLike newLike = new PlaceLike(member, place);
+            matzipRepository.save(newLike);
+
+            place.increaseLikeCount();
+            return new LikeToggleResponse(true, place.getLikeCount()); // isLiked: true, 업데이트된 카운트
+        }
     }
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/domain/MatzipService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/domain/MatzipService.java
@@ -1,0 +1,57 @@
+package io.dodn.springboot.matzip.domain;
+
+import io.dodn.springboot.matzip.controller.response.PlaceResponse;
+import io.dodn.springboot.storage.db.matzip.MatzipRepository;
+import io.dodn.springboot.storage.db.matzip.entity.Place;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class MatzipService {
+    private final MatzipRepository matzipRepository;
+
+    public MatzipService(final MatzipRepository matzipRepository) {
+        this.matzipRepository = matzipRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PlaceResponse> findAllPlaces(final Long memberId, final Pageable pageable) {
+        // 1. 맛집 목록을 페이지네이션하여 조회합니다.
+        Page<Place> places = matzipRepository.findAll(pageable);
+        List<Place> placeList = places.getContent();
+
+        if (placeList.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        // 2. 현재 로그인한 사용자의 좋아요 상태를 확인합니다.
+        Set<Long> likedPlaceIds = getLikedPlaceIds(memberId, placeList);
+
+        // 3. Place 엔티티를 PlaceResponse DTO로 변환하면서, 좋아요 상태를 설정합니다.
+        return places.map(place -> {
+            return PlaceResponse.of(place, likedPlaceIds.contains(place.getId()));
+        });
+    }
+
+    private Set<Long> getLikedPlaceIds(final Long memberId, final List<Place> placeList) {
+        // 비로그인 사용자의 경우, 빈 Set을 반환합니다.
+        if (memberId == null) {
+            return Collections.emptySet();
+        }
+
+        // 조회된 맛집들의 ID 목록을 추출합니다.
+        List<Long> placeIds = placeList.stream()
+                .map(Place::getId)
+                .collect(Collectors.toList());
+
+        // 한 번의 쿼리로 현재 사용자가 좋아요를 누른 맛집 ID 목록을 가져옵니다.
+        return matzipRepository.findLikedPlaceIdsByMemberAndPlaceIds(memberId, placeIds);
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/domain/MatzipService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/domain/MatzipService.java
@@ -39,7 +39,6 @@ public class MatzipService {
             final Long memberId,
             final Pageable pageable
     ) {
-//        Page<Place> places = matzipRepository.findAll(pageable);
         Page<Place> places = matzipRepository.findAllWithCategories(pageable);
         List<Place> placeList = places.getContent();
 
@@ -119,7 +118,7 @@ public class MatzipService {
             case "likeCount" ->
                 // 좋아요 순으로 정렬하는 쿼리 호출
                     matzipRepository.findNearbyPlacesOrderByLikeCount(pointWkt, radius, pageable);
-            case "name" ->
+            case "id" ->
                 // 이름 순으로 정렬하는 쿼리 호출
                     matzipRepository.findNearbyPlacesOrderByName(pointWkt, radius, pageable);
             default ->

--- a/core/core-api/src/main/java/io/dodn/springboot/matzip/exception/NotFoundPlaceException.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/matzip/exception/NotFoundPlaceException.java
@@ -1,0 +1,7 @@
+package io.dodn.springboot.matzip.exception;
+
+public class NotFoundPlaceException extends RuntimeException {
+    public NotFoundPlaceException(String message) {
+        super(message);
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/member/controller/MemberController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/member/controller/MemberController.java
@@ -4,9 +4,11 @@ import io.dodn.springboot.common.annotation.LoginUser;
 import io.dodn.springboot.common.support.response.ApiResponse;
 import io.dodn.springboot.common.swagger.MemberDocs;
 import io.dodn.springboot.member.controller.request.UpdateMemberRequest;
+import io.dodn.springboot.member.controller.response.ImageUrlResponse;
 import io.dodn.springboot.member.controller.response.MemberResponse;
 import io.dodn.springboot.member.controller.response.MembersResponse;
 import io.dodn.springboot.member.domain.MemberService;
+import io.dodn.springboot.storage.db.member.entity.Member;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +17,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/member")
@@ -57,6 +61,16 @@ public class MemberController implements MemberDocs {
             @RequestBody UpdateMemberRequest updateMemberRequest
     ) {
         return ApiResponse.success(MemberResponse.of(memberService.updateMember(memberId, updateMemberRequest.toEntity())));
+    }
+
+    @GetMapping("/members/images")
+    public ApiResponse<List<ImageUrlResponse>> getMemberUrls(){
+        List<Member> allMembers = memberService.findAllMembersWithTeamUsingFetchJoin();
+        List<ImageUrlResponse> imageUrls = allMembers.stream()
+                .map(ImageUrlResponse::of)
+                .toList();
+
+        return ApiResponse.success(imageUrls);
     }
 
     @PreAuthorize("hasRole('ADMIN')")

--- a/core/core-api/src/main/java/io/dodn/springboot/member/controller/MemberController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import io.dodn.springboot.storage.db.member.entity.Member;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,7 +33,7 @@ public class MemberController implements MemberDocs {
     }
 
     @GetMapping("/me")
-    public ApiResponse<MemberResponse> getMemberById(
+    public ApiResponse<MemberResponse> getMemberByIdMe(
             @Parameter(hidden = true) @LoginUser final Long memberId
     ) {
         return ApiResponse.success(MemberResponse.of(memberService.findMemberById(memberId)));
@@ -71,6 +72,13 @@ public class MemberController implements MemberDocs {
                 .toList();
 
         return ApiResponse.success(imageUrls);
+    }
+
+    @GetMapping("/{memberId}")
+    public ApiResponse<MemberResponse> getMemberById(
+            @PathVariable("memberId") final Long memberId
+    ) {
+        return ApiResponse.success(MemberResponse.of(memberService.findMemberById(memberId)));
     }
 
     @PreAuthorize("hasRole('ADMIN')")

--- a/core/core-api/src/main/java/io/dodn/springboot/member/controller/MemberController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/member/controller/MemberController.java
@@ -12,10 +12,12 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/v1/member")
 public class MemberController implements MemberDocs {
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MemberController.class);
 
@@ -25,19 +27,19 @@ public class MemberController implements MemberDocs {
         this.memberService = memberService;
     }
 
-    @GetMapping("/members/me")
+    @GetMapping("/me")
     public ApiResponse<MemberResponse> getMemberById(
             @Parameter(hidden = true) @LoginUser final Long memberId
     ) {
         return ApiResponse.success(MemberResponse.of(memberService.findMemberById(memberId)));
     }
 
-    @GetMapping("/members")
+    @GetMapping("/all")
     public ApiResponse<MembersResponse> getMembersWithTeam() {
         return ApiResponse.success(MembersResponse.of(memberService.findAllMembersWithTeamUsingFetchJoin()));
     }
 
-    @GetMapping("/members/count")
+    @GetMapping("/all/count")
     public ApiResponse<Long> getMemberCount() {
         return ApiResponse.success(memberService.countMembers());
     }
@@ -49,7 +51,7 @@ public class MemberController implements MemberDocs {
         return ApiResponse.success(MembersResponse.of(memberService.findAllMemberByTeamId(teamId)));
     }
 
-    @PutMapping("/members/me")
+    @PutMapping("/me")
     public ApiResponse<MemberResponse> updateMember(
             @Parameter(hidden = true) @LoginUser final Long memberId,
             @RequestBody UpdateMemberRequest updateMemberRequest
@@ -58,7 +60,7 @@ public class MemberController implements MemberDocs {
     }
 
     @PreAuthorize("hasRole('ADMIN')")
-    @GetMapping("/member/role")
+    @GetMapping("/role")
     public ApiResponse<String> getTest() {
         log.info("apia 호출됨??");
         return ApiResponse.success("Test success");

--- a/core/core-api/src/main/java/io/dodn/springboot/member/controller/request/UpdateMemberRequest.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/member/controller/request/UpdateMemberRequest.java
@@ -2,8 +2,6 @@ package io.dodn.springboot.member.controller.request;
 
 import io.dodn.springboot.storage.db.member.entity.Member;
 
-import java.time.LocalDate;
-
 public record UpdateMemberRequest(
         String name,
         String email,
@@ -12,7 +10,7 @@ public record UpdateMemberRequest(
         String nickname,
         String profileImageUrl,
         String kiringImageUrl,
-        LocalDate birthday,
+        String birthday,
         String githubId,
         boolean isEmployed,
         boolean isAdmin
@@ -30,6 +28,7 @@ public record UpdateMemberRequest(
                 githubId,
                 isEmployed,
                 isAdmin,
+                null,
                 null // 팀 정보는 별도로 설정하지 않음
         );
     }

--- a/core/core-api/src/main/java/io/dodn/springboot/member/controller/response/ImageUrlResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/member/controller/response/ImageUrlResponse.java
@@ -1,0 +1,16 @@
+package io.dodn.springboot.member.controller.response;
+
+import io.dodn.springboot.storage.db.member.entity.Member;
+
+public record ImageUrlResponse(
+        String kiringImageUrl,
+        String profileImageUrl
+) {
+    public static ImageUrlResponse of(Member member) {
+        return new ImageUrlResponse(member.getKiringImageUrl(), member.getProfileImageUrl());
+    }
+
+    public String getKiringImageUrl() {
+        return kiringImageUrl;
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/member/domain/MemberService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/member/domain/MemberService.java
@@ -23,16 +23,16 @@ public class MemberService {
         this.memberRepository = memberRepository;
     }
 
-    public Member createMember(Member member) {
+    public Member createMember(final Member member) {
         return memberRepository.save(member);
     }
 
-    public Member findMemberById(Long id) {
+    public Member findMemberById(final Long id) {
         return memberRepository.findById(id)
             .orElseThrow(() -> new NotFoundMemberException("Member not found with id: " + id));
     }
 
-    public void deleteMember(Long id) {
+    public void deleteMember(final Long id) {
         memberRepository.deleteById(id);
     }
 

--- a/core/core-api/src/main/java/io/dodn/springboot/member/domain/MemberService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/member/domain/MemberService.java
@@ -2,12 +2,14 @@ package io.dodn.springboot.member.domain;
 
 import io.dodn.springboot.auth.kakao.dto.KakaoUserInfoResponse;
 import io.dodn.springboot.member.exception.NotFoundMemberException;
+import io.dodn.springboot.member.exception.NotFoundPhoneException;
 import io.dodn.springboot.storage.db.member.MemberRepository;
 import io.dodn.springboot.storage.db.member.entity.Member;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -69,6 +71,9 @@ public class MemberService {
     }
 
     private String changePhoneNumber(String phoneNumber) {
+        if (!StringUtils.hasText(phoneNumber)) {
+            throw new NotFoundPhoneException("폰번호가 존재하지 않습니다.");
+        }
         return "0".concat(phoneNumber.substring(4));
     }
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/member/exception/NotFoundPhoneException.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/member/exception/NotFoundPhoneException.java
@@ -1,0 +1,7 @@
+package io.dodn.springboot.member.exception;
+
+public class NotFoundPhoneException extends RuntimeException {
+    public NotFoundPhoneException(String message) {
+        super(message);
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/plane/controller/PlaneController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/plane/controller/PlaneController.java
@@ -1,18 +1,23 @@
 package io.dodn.springboot.plane.controller;
 
+import io.dodn.springboot.common.annotation.LoginUser;
 import io.dodn.springboot.common.support.response.ApiResponse;
 import io.dodn.springboot.common.swagger.PlaneDocs;
-import io.dodn.springboot.plane.controller.request.ReadMessageRequest;
 import io.dodn.springboot.plane.controller.request.SendMessageRequest;
+import io.dodn.springboot.plane.controller.response.MessageResponse;
 import io.dodn.springboot.plane.controller.response.SendMessageResponse;
+import io.dodn.springboot.plane.controller.response.TodayMessageResponse;
+import io.dodn.springboot.plane.domain.PlaneInfo;
 import io.dodn.springboot.plane.domain.PlaneService;
 import io.dodn.springboot.storage.db.plane.entity.Plane;
 import jakarta.validation.Valid;
-import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/plane")
@@ -25,15 +30,30 @@ public class PlaneController implements PlaneDocs {
     }
 
     @PostMapping("/send-message")
-    public ApiResponse<SendMessageResponse> sendMessage(@Valid @RequestBody SendMessageRequest request) {
+    public ApiResponse<SendMessageResponse> sendMessage(
+            @Valid @RequestBody SendMessageRequest request
+    ) {
         Plane plane = planeService.sendMessage(request);
         return ApiResponse.success(SendMessageResponse.fromEntity(plane));
     }
 
-    @PatchMapping("/read")
-    public ApiResponse<?> readMessage(@Valid @RequestBody ReadMessageRequest request) {
-        planeService.readMessage(request);
-        return ApiResponse.success();
+    @GetMapping("/read")
+    public ApiResponse<List<MessageResponse>> readMessage(
+            @LoginUser long readerId
+    ) {
+        final List<PlaneInfo> planeInfos = planeService.readMessage(readerId);
+
+        return ApiResponse.success(
+                planeInfos.stream()
+                .map(MessageResponse::fromEntity)
+                .toList()
+        );
     }
 
+    @GetMapping("/today/message")
+    public ApiResponse<TodayMessageResponse> getTodayMessage(
+            @LoginUser long readerId
+    ) {
+        return ApiResponse.success(TodayMessageResponse.of(planeService.getTodayMessage(readerId)));
+    }
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/plane/controller/PlaneController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/plane/controller/PlaneController.java
@@ -11,9 +11,11 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/v1/plane")
 public class PlaneController implements PlaneDocs {
 
     private final PlaneService planeService;
@@ -22,13 +24,13 @@ public class PlaneController implements PlaneDocs {
         this.planeService = planeService;
     }
 
-    @PostMapping("/plane/send-message")
+    @PostMapping("/send-message")
     public ApiResponse<SendMessageResponse> sendMessage(@Valid @RequestBody SendMessageRequest request) {
         Plane plane = planeService.sendMessage(request);
         return ApiResponse.success(SendMessageResponse.fromEntity(plane));
     }
 
-    @PatchMapping("/plane/read")
+    @PatchMapping("/read")
     public ApiResponse<?> readMessage(@Valid @RequestBody ReadMessageRequest request) {
         planeService.readMessage(request);
         return ApiResponse.success();

--- a/core/core-api/src/main/java/io/dodn/springboot/plane/controller/request/SendMessageRequest.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/plane/controller/request/SendMessageRequest.java
@@ -14,4 +14,5 @@ public record SendMessageRequest(
         String message
 ) {
 
+
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/plane/controller/response/MessageResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/plane/controller/response/MessageResponse.java
@@ -1,0 +1,24 @@
+package io.dodn.springboot.plane.controller.response;
+
+import io.dodn.springboot.plane.domain.PlaneInfo;
+
+import java.time.LocalDateTime;
+
+public record  MessageResponse(
+        Long messageId,
+        Long receiverId,
+        SenderResponse sender,
+        String message,
+        LocalDateTime sentAt
+) {
+
+    public static MessageResponse fromEntity(PlaneInfo planeInfo) {
+        return new MessageResponse(
+                planeInfo.messageId(),
+                planeInfo.receiverId(),
+                planeInfo.sender(),
+                planeInfo.message(),
+                planeInfo.sentAt()
+        );
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/plane/controller/response/SenderResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/plane/controller/response/SenderResponse.java
@@ -1,0 +1,17 @@
+package io.dodn.springboot.plane.controller.response;
+
+import io.dodn.springboot.storage.db.member.entity.Member;
+
+public record SenderResponse(
+        Long id,
+        String name,
+        String profileImageUrl
+) {
+    public static SenderResponse from(Member member) {
+        return new SenderResponse(
+                member.getId(),
+                member.getNickname(),
+                member.getProfileImageUrl()
+        );
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/plane/controller/response/TodayMessageResponse.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/plane/controller/response/TodayMessageResponse.java
@@ -1,0 +1,9 @@
+package io.dodn.springboot.plane.controller.response;
+
+public record TodayMessageResponse(
+        boolean hasTodayMessage
+) {
+    public static TodayMessageResponse of(final boolean todayMessage) {
+        return new TodayMessageResponse(todayMessage);
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/plane/domain/PlaneInfo.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/plane/domain/PlaneInfo.java
@@ -1,0 +1,30 @@
+package io.dodn.springboot.plane.domain;
+
+import io.dodn.springboot.plane.controller.response.SenderResponse;
+import io.dodn.springboot.storage.db.plane.entity.Plane;
+
+import java.time.LocalDateTime;
+
+public record PlaneInfo(
+        Long messageId,
+        Long receiverId,
+        SenderResponse sender,
+        String message,
+        LocalDateTime sentAt
+) {
+    public static PlaneInfo fromEntity(Plane plane) {
+        SenderResponse senderResponse = new SenderResponse(
+                plane.getSender().getId(),
+                plane.getSender().getName(),
+                plane.getSender().getProfileImageUrl()
+        );
+
+        return new PlaneInfo(
+                plane.getId(),
+                plane.getReceiver().getId(),
+                senderResponse,
+                plane.getMessage(),
+                plane.getCreatedAt()
+        );
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/plane/domain/PlaneService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/plane/domain/PlaneService.java
@@ -25,16 +25,16 @@ public class PlaneService {
 
     public Plane sendMessage(final @Valid SendMessageRequest request) {
         final Member sender = memberRepository.findById(request.senderId())
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND_MEMBER, "Member not found with id: " + request.senderId()));
+                .orElseThrow(() -> new CoreException(ErrorType.ERR_1001, "Member not found with id: " + request.senderId()));
 
         final Member receiver = memberRepository.findById(request.receiverId())
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND_MEMBER, "Member not found with id: " + request.receiverId()));
+                .orElseThrow(() -> new CoreException(ErrorType.ERR_1001, "Member not found with id: " + request.receiverId()));
 
 
         // 실제로는 자기 자신에게 쪽지를 보내는 등의 비즈니스 규칙 검사도 추가될 수 있음
         if (sender.getId().equals(receiver.getId())) {
             // 예외 처리 또는 다른 로직 (여기서는 간단히 예외로 가정)
-            throw new CoreException(ErrorType.DEFAULT_ERROR, "자기 자신에게 쪽지를 보낼 수 없습니다.");
+            throw new CoreException(ErrorType.ERR_1099, "자기 자신에게 쪽지를 보낼 수 없습니다.");
         }
 
         final Plane plane = Plane.create(

--- a/core/core-api/src/main/java/io/dodn/springboot/plane/domain/PlaneService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/plane/domain/PlaneService.java
@@ -72,10 +72,10 @@ public class PlaneService {
 
     public boolean getTodayMessage(final long readerId) {
         LocalDate today = LocalDate.now();
-        LocalDateTime startOfDay = today.atStartOfDay();
-        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+        LocalDateTime startOfDay = today.atStartOfDay(); // 오늘 날짜의 00:00:00
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);   // 오늘 날짜의 23:59:59
 
-        List<Plane> planeList = planeRepository.findByReceiverId(readerId);
+        List<Plane> planeList = planeRepository.findByReceiverIdAndCreatedAtBetween(readerId, startOfDay, endOfDay);
         return !planeList.isEmpty();
     }
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/plane/domain/PlaneService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/plane/domain/PlaneService.java
@@ -2,15 +2,17 @@ package io.dodn.springboot.plane.domain;
 
 import io.dodn.springboot.common.support.error.CoreException;
 import io.dodn.springboot.common.support.error.ErrorType;
-import io.dodn.springboot.plane.controller.request.ReadMessageRequest;
 import io.dodn.springboot.plane.controller.request.SendMessageRequest;
 import io.dodn.springboot.storage.db.member.MemberRepository;
 import io.dodn.springboot.storage.db.member.entity.Member;
 import io.dodn.springboot.storage.db.plane.PlaneRepository;
 import io.dodn.springboot.storage.db.plane.entity.Plane;
-import jakarta.validation.Valid;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 @Service
@@ -23,7 +25,9 @@ public class PlaneService {
         this.memberRepository = memberRepository;
     }
 
-    public Plane sendMessage(final @Valid SendMessageRequest request) {
+    public Plane sendMessage(
+            final SendMessageRequest request
+    ) {
         final Member sender = memberRepository.findById(request.senderId())
                 .orElseThrow(() -> new CoreException(ErrorType.ERR_1001, "Member not found with id: " + request.senderId()));
 
@@ -31,10 +35,21 @@ public class PlaneService {
                 .orElseThrow(() -> new CoreException(ErrorType.ERR_1001, "Member not found with id: " + request.receiverId()));
 
 
-        // 실제로는 자기 자신에게 쪽지를 보내는 등의 비즈니스 규칙 검사도 추가될 수 있음
+        // 자기 자신에게 쪽지를 보내는 등의 비즈니스 규칙 검사도 추가될 수 있음
         if (sender.getId().equals(receiver.getId())) {
             // 예외 처리 또는 다른 로직 (여기서는 간단히 예외로 가정)
             throw new CoreException(ErrorType.ERR_1099, "자기 자신에게 쪽지를 보낼 수 없습니다.");
+        }
+
+        // 하루에 한 번만 보내기 로직 추가
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay(); // 오늘 날짜의 00:00:00
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);   // 오늘 날짜의 23:59:59
+
+        boolean alreadySentToday = planeRepository.existsBySenderAndCreatedAtBetween(sender, startOfDay, endOfDay);
+
+        if (alreadySentToday) {
+            throw new CoreException(ErrorType.ERR_1006, "같은 사람에게는 하루에 한 번만 쪽지를 보낼 수 있습니다.");
         }
 
         final Plane plane = Plane.create(
@@ -46,9 +61,21 @@ public class PlaneService {
     }
 
 
-    public void readMessage(final @Valid ReadMessageRequest request) {
-        // 쪽지 읽기 로직 구현
-        final List<Plane> planeList = planeRepository.findByReceiverId(request.readerId());
-        planeList.forEach(Plane::markAsRead);
+    @Transactional(readOnly = true)
+    public List<PlaneInfo> readMessage(final long readerId) {
+        final List<Plane> planeList = planeRepository.findByReceiverId(readerId);
+
+        return planeList.stream()
+                .map(PlaneInfo::fromEntity)
+                .toList();
+    }
+
+    public boolean getTodayMessage(final long readerId) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+        List<Plane> planeList = planeRepository.findByReceiverId(readerId);
+        return !planeList.isEmpty();
     }
 }

--- a/core/core-api/src/main/java/io/dodn/springboot/plane/domain/PlaneService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/plane/domain/PlaneService.java
@@ -48,9 +48,9 @@ public class PlaneService {
 
         boolean alreadySentToday = planeRepository.existsBySenderAndCreatedAtBetween(sender, startOfDay, endOfDay);
 
-        if (alreadySentToday) {
-            throw new CoreException(ErrorType.ERR_1006, "같은 사람에게는 하루에 한 번만 쪽지를 보낼 수 있습니다.");
-        }
+//        if (alreadySentToday) {
+//            throw new CoreException(ErrorType.ERR_1006, "하루에 한 번만 쪽지를 보낼 수 있습니다.");
+//        }
 
         final Plane plane = Plane.create(
                 sender,

--- a/core/core-api/src/main/java/io/dodn/springboot/upload/controller/UploadController.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/upload/controller/UploadController.java
@@ -1,0 +1,41 @@
+package io.dodn.springboot.upload.controller;
+
+import io.dodn.springboot.common.support.error.ErrorType;
+import io.dodn.springboot.common.support.response.ApiResponse;
+import io.dodn.springboot.upload.domain.UploadService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+public class UploadController {
+    private final UploadService uploadService;
+
+    public UploadController(final UploadService uploadService) {
+        this.uploadService = uploadService;
+    }
+
+    @PostMapping(value = "/places/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<String>> uploadPlacesFromExcel(
+            @RequestParam("file") MultipartFile file
+    ) {
+        if (file.isEmpty()) {
+            return ResponseEntity.badRequest().body(ApiResponse.error(ErrorType.ERR_1007, "파일이 비어있습니다."));
+        }
+
+        try {
+            int count = uploadService.savePlaceDataFromExcel(file);
+            String message = String.format("총 %d개의 맛집 데이터가 성공적으로 등록되었습니다.", count);
+            return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(message));
+        } catch (Exception e) {
+            // 구체적인 예외 처리를 추가하는 것이 좋습니다.
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.error(ErrorType.ERR_1008,"엑셀 파일 처리 중 오류가 발생했습니다: " + e.getMessage()));
+        }
+    }
+}

--- a/core/core-api/src/main/java/io/dodn/springboot/upload/domain/UploadService.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/upload/domain/UploadService.java
@@ -1,0 +1,168 @@
+package io.dodn.springboot.upload.domain;
+
+import io.dodn.springboot.storage.db.matzip.MatzipRepository;
+import io.dodn.springboot.storage.db.matzip.entity.Category;
+import io.dodn.springboot.storage.db.matzip.entity.Menu;
+import io.dodn.springboot.storage.db.matzip.entity.Place;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class UploadService {
+    private static final Logger log = LoggerFactory.getLogger(UploadService.class);
+    private final MatzipRepository matzipRepository;
+
+    private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    public UploadService(final MatzipRepository matzipRepository) {
+        this.matzipRepository = matzipRepository;
+    }
+
+    @Transactional
+    public int savePlaceDataFromExcel(final MultipartFile file) {
+        List<Place> placesToSave = new ArrayList<>();
+
+        try (InputStream is = file.getInputStream()) {
+            Workbook workbook = new XSSFWorkbook(is);
+            Sheet sheet = workbook.getSheetAt(0);
+
+            for (int i = 1; i <= sheet.getLastRowNum(); i++) {
+                Row row = sheet.getRow(i);
+                if (row == null || row.getCell(1) == null || row.getCell(1).getCellType() == CellType.BLANK) {
+                    continue;
+                }
+
+                try {
+                    String name = getStringCellValue(row, 1);
+                    String naverCategory = getStringCellValue(row, 2);
+                    String categoryString = getStringCellValue(row, 3);
+                    String address = getStringCellValue(row, 4);
+                    double latitude = getNumericCellValue(row, 5);
+                    double longitude = getNumericCellValue(row, 6);
+                    String phoneNumber = getStringCellValue(row, 7);
+                    String menuString = getStringCellValue(row, 8); // 메뉴 문자열 (예: "꼬치,맥주")
+                    String imageUrl = getStringCellValue(row, 9);
+
+                    // 위도, 경도가 0이 아닌 유효한 값인지 확인
+                    if (latitude == 0.0 || longitude == 0.0) {
+                        log.warn("엑셀 파일의 {}번째 행에 유효하지 않은 좌표 정보가 있어 건너뜁니다: {}", i + 1, name);
+                        continue;
+                    }
+
+                    Point location = geometryFactory.createPoint(new Coordinate(longitude, latitude));
+                    Place place = new Place(
+                            name,
+                            address,
+                            naverCategory,
+                            imageUrl,
+                            phoneNumber,
+                            null,
+                            0,
+                            location,
+                            new ArrayList<>()
+                    );
+                    place.setCategories(new HashSet<>()); // 카테고리 Set 초기화
+
+                    if (StringUtils.hasText(categoryString)) {
+                        List<String> categoryNames = Arrays.stream(categoryString.split(","))
+                                .map(String::trim)
+                                .filter(StringUtils::hasText)
+                                .toList();
+
+                        // DB에서 이미 존재하는 카테고리들을 한 번에 조회
+                        List<Category> existingCategories = matzipRepository.categoryFindByNameIn(categoryNames);
+                        Set<String> existingCategoryNames = existingCategories.stream()
+                                .map(Category::getName)
+                                .collect(Collectors.toSet());
+
+                        // DB에 없는 새로운 카테고리들을 찾아 생성
+                        for (String categoryName : categoryNames) {
+                            if (!existingCategoryNames.contains(categoryName)) {
+                                Category newCategory = new Category(categoryName);
+                                existingCategories.add(matzipRepository.saveCategory(newCategory));
+                            }
+                        }
+
+                        existingCategories.forEach(place::addCategory);
+                    }
+
+                    if (StringUtils.hasText(menuString)) {
+                        Arrays.stream(menuString.split(","))
+                                .map(String::trim)
+                                .filter(StringUtils::hasText)
+                                .forEach(menuName -> {
+                                    Menu menu = new Menu(menuName, 0, null, null, false, null);
+                                    place.addMenu(menu);
+                                });
+                    }
+                    log.info("### Excel Place : {}", place);
+                    placesToSave.add(place);
+
+                } catch (Exception e) {
+                    log.error("엑셀 파일의 {}번째 행 처리 중 오류 발생: {}", i + 1, e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            log.error("엑셀 파일을 읽는 중 오류가 발생했습니다.", e);
+            throw new RuntimeException("엑셀 파일을 읽는 중 오류가 발생했습니다.", e);
+        }
+
+        matzipRepository.saveAll(placesToSave);
+        return placesToSave.size();
+    }
+
+    // 셀의 문자열 값을 안전하게 가져오는 헬퍼 메서드
+    private String getStringCellValue(Row row, int cellNum) {
+        Cell cell = row.getCell(cellNum);
+        if (cell == null) {
+            return ""; // 빈 셀은 빈 문자열로 처리
+        }
+        // 셀 타입에 따라 다르게 처리
+        if (cell.getCellType() == CellType.STRING) {
+            return cell.getStringCellValue().trim();
+        } else if (cell.getCellType() == CellType.NUMERIC) {
+            // 숫자가 문자열로 저장된 경우를 대비
+            return String.valueOf((long) cell.getNumericCellValue());
+        }
+        return "";
+    }
+
+    // 셀의 숫자 값을 안전하게 가져오는 헬퍼 메서드
+    private double getNumericCellValue(Row row, int cellNum) {
+        Cell cell = row.getCell(cellNum);
+        if (cell == null) {
+            return 0.0;
+        }
+        if (cell.getCellType() == CellType.NUMERIC) {
+            return cell.getNumericCellValue();
+        }
+        // 문자열로 된 숫자를 파싱
+        try {
+            return Double.parseDouble(cell.getStringCellValue());
+        } catch (NumberFormatException e) {
+            return 0.0;
+        }
+    }
+}

--- a/core/core-api/src/main/resources/application.yml
+++ b/core/core-api/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
             client-secret: zNvmJgdyPC6arlK2pGiFAfES2xRy0fKk
 #            client-secret: WFQrG7VFVbqU4BhVTm82Pbi6cYOw000o
             client-authentication-method: client_secret_post
-            redirect-uri: "https://{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
             client-name: kakao
             scope: account_email,phone_number,name,profile_nickname
@@ -37,6 +37,7 @@ kakao:
 
 
 server:
+  forward-headers-strategy: native
   tomcat:
     max-connections: 20000
     threads:

--- a/core/core-api/src/main/resources/application.yml
+++ b/core/core-api/src/main/resources/application.yml
@@ -14,10 +14,10 @@ spring:
       client:
         registration:
           kakao:
-            client-id: 9aebe1e49481851b5f2926e02e59500a
-#            client-id: a5b6241a2b7b4a84498c605475fe2b07
-            client-secret: zNvmJgdyPC6arlK2pGiFAfES2xRy0fKk
-#            client-secret: WFQrG7VFVbqU4BhVTm82Pbi6cYOw000o
+#            client-id: 9aebe1e49481851b5f2926e02e59500a
+            client-id: a5b6241a2b7b4a84498c605475fe2b07
+#            client-secret: zNvmJgdyPC6arlK2pGiFAfES2xRy0fKk
+            client-secret: WFQrG7VFVbqU4BhVTm82Pbi6cYOw000o
             client-authentication-method: client_secret_post
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code

--- a/core/core-api/src/main/resources/application.yml
+++ b/core/core-api/src/main/resources/application.yml
@@ -15,9 +15,10 @@ spring:
         registration:
           kakao:
             client-id: 9aebe1e49481851b5f2926e02e59500a
+#            client-id: a5b6241a2b7b4a84498c605475fe2b07
             client-secret: zNvmJgdyPC6arlK2pGiFAfES2xRy0fKk
+#            client-secret: WFQrG7VFVbqU4BhVTm82Pbi6cYOw000o
             client-authentication-method: client_secret_post
-#            redirect-uri: http://localhost:8080/api/v1/oauth/kakao/callback
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
             client-name: kakao

--- a/core/core-api/src/main/resources/application.yml
+++ b/core/core-api/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
             client-secret: zNvmJgdyPC6arlK2pGiFAfES2xRy0fKk
 #            client-secret: WFQrG7VFVbqU4BhVTm82Pbi6cYOw000o
             client-authentication-method: client_secret_post
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "https://{baseUrl}/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
             client-name: kakao
             scope: account_email,phone_number,name,profile_nickname

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/common/entity/EventCategory.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/common/entity/EventCategory.java
@@ -1,0 +1,20 @@
+package io.dodn.springboot.storage.db.common.entity;
+
+public enum EventCategory {
+    BIRTHDAY("생일"),
+    STUDY("스터디"),
+    DINNER( "회식"),
+    HOLIDAY("휴일"),
+    NOTICE("공지");
+
+    private final String description;
+
+    EventCategory(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/EventRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/EventRepository.java
@@ -1,0 +1,10 @@
+package io.dodn.springboot.storage.db.event;
+
+import io.dodn.springboot.storage.db.event.entity.Event;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface EventRepository {
+    List<Event> findEventsForPeriod(LocalDateTime startDate, LocalDateTime endDate);
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/adapter/EventRepositoryAdapter.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/adapter/EventRepositoryAdapter.java
@@ -1,0 +1,22 @@
+package io.dodn.springboot.storage.db.event.adapter;
+
+import io.dodn.springboot.storage.db.event.EventRepository;
+import io.dodn.springboot.storage.db.event.entity.Event;
+import io.dodn.springboot.storage.db.event.repository.EventJpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class EventRepositoryAdapter implements EventRepository {
+    private final EventJpaRepository eventJpaRepository;
+
+    public EventRepositoryAdapter(final EventJpaRepository eventJpaRepository) {
+        this.eventJpaRepository = eventJpaRepository;
+    }
+
+
+    @Override
+    public List<Event> findEventsForPeriod(final LocalDateTime startDate, final LocalDateTime endDate) {
+        return List.of();
+    }
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/adapter/EventRepositoryAdapter.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/adapter/EventRepositoryAdapter.java
@@ -3,10 +3,12 @@ package io.dodn.springboot.storage.db.event.adapter;
 import io.dodn.springboot.storage.db.event.EventRepository;
 import io.dodn.springboot.storage.db.event.entity.Event;
 import io.dodn.springboot.storage.db.event.repository.EventJpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Repository
 public class EventRepositoryAdapter implements EventRepository {
     private final EventJpaRepository eventJpaRepository;
 
@@ -17,6 +19,6 @@ public class EventRepositoryAdapter implements EventRepository {
 
     @Override
     public List<Event> findEventsForPeriod(final LocalDateTime startDate, final LocalDateTime endDate) {
-        return List.of();
+        return eventJpaRepository.findAllByStartDatetimeBetweenOrderByEventCategoryAsc(startDate, endDate);
     }
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/entity/Event.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/entity/Event.java
@@ -42,6 +42,9 @@ public class Event extends BaseEntity {
     @JoinColumn(name = "team_id", nullable = false)
     private Team team;
 
+    public Event() {
+    }
+
     public Event(
             final String title,
             final String description,

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/entity/Event.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/entity/Event.java
@@ -1,0 +1,90 @@
+package io.dodn.springboot.storage.db.event.entity;
+
+import io.dodn.springboot.storage.db.common.entity.BaseEntity;
+import io.dodn.springboot.storage.db.common.entity.EventCategory;
+import io.dodn.springboot.storage.db.member.entity.Member;
+import io.dodn.springboot.storage.db.member.entity.Team;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "event")
+public class Event extends BaseEntity {
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    private LocalDateTime startDatetime;
+
+    @Column(nullable = false)
+    private LocalDateTime endDatetime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EventCategory eventCategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id", nullable = false)
+    private Member creator;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    public Event(
+            final String title,
+            final String description,
+            final LocalDateTime startDatetime,
+            final LocalDateTime endDatetime,
+            final EventCategory eventCategory,
+            final Member creator,
+            final Team team
+    ) {
+        this.title = title;
+        this.description = description;
+        this.startDatetime = startDatetime;
+        this.endDatetime = endDatetime;
+        this.eventCategory = eventCategory;
+        this.creator = creator;
+        this.team = team;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public LocalDateTime getStartDatetime() {
+        return startDatetime;
+    }
+
+    public LocalDateTime getEndDatetime() {
+        return endDatetime;
+    }
+
+    public EventCategory getEventCategory() {
+        return eventCategory;
+    }
+
+    public Member getCreator() {
+        return creator;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/repository/EventJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/repository/EventJpaRepository.java
@@ -3,6 +3,10 @@ package io.dodn.springboot.storage.db.event.repository;
 import io.dodn.springboot.storage.db.event.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface EventJpaRepository extends JpaRepository<Event, Long> {
 
+    List<Event> findAllByStartDatetimeBetweenOrderByEventCategoryAsc(LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/repository/EventJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/event/repository/EventJpaRepository.java
@@ -1,0 +1,8 @@
+package io.dodn.springboot.storage.db.event.repository;
+
+import io.dodn.springboot.storage.db.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventJpaRepository extends JpaRepository<Event, Long> {
+
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/MatzipRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/MatzipRepository.java
@@ -1,0 +1,14 @@
+package io.dodn.springboot.storage.db.matzip;
+
+import io.dodn.springboot.storage.db.matzip.entity.Place;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Set;
+
+public interface MatzipRepository {
+    Page<Place> findAll(Pageable pageable);
+
+    Set<Long> findLikedPlaceIdsByMemberAndPlaceIds(Long memberId, List<Long> placeIds);
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/MatzipRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/MatzipRepository.java
@@ -1,14 +1,24 @@
 package io.dodn.springboot.storage.db.matzip;
 
 import io.dodn.springboot.storage.db.matzip.entity.Place;
+import io.dodn.springboot.storage.db.matzip.entity.PlaceLike;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface MatzipRepository {
     Page<Place> findAll(Pageable pageable);
 
     Set<Long> findLikedPlaceIdsByMemberAndPlaceIds(Long memberId, List<Long> placeIds);
+
+    Optional<PlaceLike> findByMemberIdAndPlaceId(Long memberId, Long placeId);
+
+    Optional<Place> findByPlaceId(Long placeId);
+
+    void delete(PlaceLike placeLike);
+
+    void save(PlaceLike newLike);
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/MatzipRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/MatzipRepository.java
@@ -25,14 +25,17 @@ public interface MatzipRepository {
 
     long countNearbyPlaces(String pointWkt, int radius);
 
-    List<PlaceWithDistance> findNearbyPlaces(String pointWkt, int radius, Pageable pageable);
-
     void saveAll(List<Place> placesToSave);
 
     Category saveCategory(Category newCategory);
 
     List<Category> categoryFindByNameIn(List<String> categoryNames);
 
+    Page<Place> findAllWithCategories(Pageable pageable);
 
+    List<PlaceWithDistance> findNearbyPlacesOrderByDistance(String pointWkt, int radius, Pageable pageable);
 
+    List<PlaceWithDistance> findNearbyPlacesOrderByName(String pointWkt, int radius, Pageable pageable);
+
+    List<PlaceWithDistance> findNearbyPlacesOrderByLikeCount(String pointWkt, int radius, Pageable pageable);
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/MatzipRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/MatzipRepository.java
@@ -21,4 +21,8 @@ public interface MatzipRepository {
     void delete(PlaceLike placeLike);
 
     void save(PlaceLike newLike);
+
+    long countNearbyPlaces(String pointWkt, int radius);
+
+    List<PlaceWithDistance> findNearbyPlaces(String pointWkt, int radius, Pageable pageable);
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/MatzipRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/MatzipRepository.java
@@ -1,5 +1,6 @@
 package io.dodn.springboot.storage.db.matzip;
 
+import io.dodn.springboot.storage.db.matzip.entity.Category;
 import io.dodn.springboot.storage.db.matzip.entity.Place;
 import io.dodn.springboot.storage.db.matzip.entity.PlaceLike;
 import org.springframework.data.domain.Page;
@@ -25,4 +26,13 @@ public interface MatzipRepository {
     long countNearbyPlaces(String pointWkt, int radius);
 
     List<PlaceWithDistance> findNearbyPlaces(String pointWkt, int radius, Pageable pageable);
+
+    void saveAll(List<Place> placesToSave);
+
+    Category saveCategory(Category newCategory);
+
+    List<Category> categoryFindByNameIn(List<String> categoryNames);
+
+
+
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/PlaceWithDistance.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/PlaceWithDistance.java
@@ -6,6 +6,7 @@ public interface PlaceWithDistance {
     String getAddress();
     String getPhoneNumber();
     String getDescription();
+    int getLikeCount();
     Double getLongitude();
     Double getLatitude();
     Double getDistance();

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/PlaceWithDistance.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/PlaceWithDistance.java
@@ -1,0 +1,12 @@
+package io.dodn.springboot.storage.db.matzip;
+
+public interface PlaceWithDistance {
+    Long getPlaceId();
+    String getName();
+    String getAddress();
+    String getPhoneNumber();
+    String getDescription();
+    Double getLongitude();
+    Double getLatitude();
+    Double getDistance();
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/adapter/MatzipRepositoryAdapter.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/adapter/MatzipRepositoryAdapter.java
@@ -69,11 +69,6 @@ public class MatzipRepositoryAdapter implements MatzipRepository {
     }
 
     @Override
-    public List<PlaceWithDistance> findNearbyPlaces(final String pointWkt, final int radius, final Pageable pageable) {
-        return placeJpaRepository.findNearbyPlaces(pointWkt, radius, pageable);
-    }
-
-    @Override
     public void saveAll(final List<Place> placesToSave) {
         placeJpaRepository.saveAll(placesToSave);
     }
@@ -86,6 +81,26 @@ public class MatzipRepositoryAdapter implements MatzipRepository {
     @Override
     public List<Category> categoryFindByNameIn(final List<String> categoryNames) {
         return categoryJpaRepository.findByNameIn(categoryNames);
+    }
+
+    @Override
+    public Page<Place> findAllWithCategories(final Pageable pageable) {
+        return placeJpaRepository.findAllWithCategories(pageable);
+    }
+
+    @Override
+    public List<PlaceWithDistance> findNearbyPlacesOrderByDistance(final String pointWkt, final int radius, final Pageable pageable) {
+        return placeJpaRepository.findNearbyPlacesOrderByDistance(pointWkt, radius, pageable);
+    }
+
+    @Override
+    public List<PlaceWithDistance> findNearbyPlacesOrderByName(final String pointWkt, final int radius, final Pageable pageable) {
+        return placeJpaRepository.findNearbyPlacesOrderByName(pointWkt, radius, pageable);
+    }
+
+    @Override
+    public List<PlaceWithDistance> findNearbyPlacesOrderByLikeCount(final String pointWkt, final int radius, final Pageable pageable) {
+        return placeJpaRepository.findNearbyPlacesOrderByLikeCount(pointWkt, radius, pageable);
     }
 
 

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/adapter/MatzipRepositoryAdapter.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/adapter/MatzipRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package io.dodn.springboot.storage.db.matzip.adapter;
 
 import io.dodn.springboot.storage.db.matzip.MatzipRepository;
+import io.dodn.springboot.storage.db.matzip.PlaceWithDistance;
 import io.dodn.springboot.storage.db.matzip.entity.Place;
 import io.dodn.springboot.storage.db.matzip.entity.PlaceLike;
 import io.dodn.springboot.storage.db.matzip.repository.MenuJpaRepository;
@@ -56,6 +57,16 @@ public class MatzipRepositoryAdapter implements MatzipRepository {
     @Override
     public void save(final PlaceLike newLike) {
         placeLikeJpaRepository.save(newLike);
+    }
+
+    @Override
+    public long countNearbyPlaces(final String pointWkt, final int radius) {
+        return placeJpaRepository.countNearbyPlaces(pointWkt, radius);
+    }
+
+    @Override
+    public List<PlaceWithDistance> findNearbyPlaces(final String pointWkt, final int radius, final Pageable pageable) {
+        return placeJpaRepository.findNearbyPlaces(pointWkt, radius, pageable);
     }
 
 

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/adapter/MatzipRepositoryAdapter.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/adapter/MatzipRepositoryAdapter.java
@@ -2,8 +2,10 @@ package io.dodn.springboot.storage.db.matzip.adapter;
 
 import io.dodn.springboot.storage.db.matzip.MatzipRepository;
 import io.dodn.springboot.storage.db.matzip.PlaceWithDistance;
+import io.dodn.springboot.storage.db.matzip.entity.Category;
 import io.dodn.springboot.storage.db.matzip.entity.Place;
 import io.dodn.springboot.storage.db.matzip.entity.PlaceLike;
+import io.dodn.springboot.storage.db.matzip.repository.CategoryJpaRepository;
 import io.dodn.springboot.storage.db.matzip.repository.MenuJpaRepository;
 import io.dodn.springboot.storage.db.matzip.repository.PlaceJpaRepository;
 import io.dodn.springboot.storage.db.matzip.repository.PlaceLikeJpaRepository;
@@ -20,11 +22,13 @@ public class MatzipRepositoryAdapter implements MatzipRepository {
     private final MenuJpaRepository menuJpaRepository;
     private final PlaceJpaRepository placeJpaRepository;
     private final PlaceLikeJpaRepository placeLikeJpaRepository;
+    private final CategoryJpaRepository categoryJpaRepository;
 
-    public MatzipRepositoryAdapter(final MenuJpaRepository menuJpaRepository, final PlaceJpaRepository placeJpaRepository, final PlaceLikeJpaRepository placeLikeJpaRepository) {
+    public MatzipRepositoryAdapter(final MenuJpaRepository menuJpaRepository, final PlaceJpaRepository placeJpaRepository, final PlaceLikeJpaRepository placeLikeJpaRepository, final CategoryJpaRepository categoryJpaRepository) {
         this.menuJpaRepository = menuJpaRepository;
         this.placeJpaRepository = placeJpaRepository;
         this.placeLikeJpaRepository = placeLikeJpaRepository;
+        this.categoryJpaRepository = categoryJpaRepository;
     }
 
 
@@ -67,6 +71,21 @@ public class MatzipRepositoryAdapter implements MatzipRepository {
     @Override
     public List<PlaceWithDistance> findNearbyPlaces(final String pointWkt, final int radius, final Pageable pageable) {
         return placeJpaRepository.findNearbyPlaces(pointWkt, radius, pageable);
+    }
+
+    @Override
+    public void saveAll(final List<Place> placesToSave) {
+        placeJpaRepository.saveAll(placesToSave);
+    }
+
+    @Override
+    public Category saveCategory(final Category newCategory) {
+        return categoryJpaRepository.save(newCategory);
+    }
+
+    @Override
+    public List<Category> categoryFindByNameIn(final List<String> categoryNames) {
+        return categoryJpaRepository.findByNameIn(categoryNames);
     }
 
 

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/adapter/MatzipRepositoryAdapter.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/adapter/MatzipRepositoryAdapter.java
@@ -1,0 +1,37 @@
+package io.dodn.springboot.storage.db.matzip.adapter;
+
+import io.dodn.springboot.storage.db.matzip.MatzipRepository;
+import io.dodn.springboot.storage.db.matzip.entity.Place;
+import io.dodn.springboot.storage.db.matzip.repository.MenuJpaRepository;
+import io.dodn.springboot.storage.db.matzip.repository.PlaceJpaRepository;
+import io.dodn.springboot.storage.db.matzip.repository.PlaceLikeJpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
+
+@Repository
+public class MatzipRepositoryAdapter implements MatzipRepository {
+    private final MenuJpaRepository menuJpaRepository;
+    private final PlaceJpaRepository placeJpaRepository;
+    private final PlaceLikeJpaRepository placeLikeJpaRepository;
+
+    public MatzipRepositoryAdapter(final MenuJpaRepository menuJpaRepository, final PlaceJpaRepository placeJpaRepository, final PlaceLikeJpaRepository placeLikeJpaRepository) {
+        this.menuJpaRepository = menuJpaRepository;
+        this.placeJpaRepository = placeJpaRepository;
+        this.placeLikeJpaRepository = placeLikeJpaRepository;
+    }
+
+
+    @Override
+    public Page<Place> findAll(final Pageable pageable) {
+        return placeJpaRepository.findAll(pageable);
+    }
+
+    @Override
+    public Set<Long> findLikedPlaceIdsByMemberAndPlaceIds(final Long memberId, final List<Long> placeIds) {
+        return placeLikeJpaRepository.findLikedPlaceIdsByMemberAndPlaceIds(memberId, placeIds);
+    }
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/adapter/MatzipRepositoryAdapter.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/adapter/MatzipRepositoryAdapter.java
@@ -2,6 +2,7 @@ package io.dodn.springboot.storage.db.matzip.adapter;
 
 import io.dodn.springboot.storage.db.matzip.MatzipRepository;
 import io.dodn.springboot.storage.db.matzip.entity.Place;
+import io.dodn.springboot.storage.db.matzip.entity.PlaceLike;
 import io.dodn.springboot.storage.db.matzip.repository.MenuJpaRepository;
 import io.dodn.springboot.storage.db.matzip.repository.PlaceJpaRepository;
 import io.dodn.springboot.storage.db.matzip.repository.PlaceLikeJpaRepository;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Repository
@@ -34,4 +36,27 @@ public class MatzipRepositoryAdapter implements MatzipRepository {
     public Set<Long> findLikedPlaceIdsByMemberAndPlaceIds(final Long memberId, final List<Long> placeIds) {
         return placeLikeJpaRepository.findLikedPlaceIdsByMemberAndPlaceIds(memberId, placeIds);
     }
+
+    @Override
+    public Optional<PlaceLike> findByMemberIdAndPlaceId(final Long memberId, final Long placeId) {
+        return placeLikeJpaRepository.findByMemberIdAndPlaceId(memberId, placeId);
+
+    }
+
+    @Override
+    public Optional<Place> findByPlaceId(final Long placeId) {
+        return placeJpaRepository.findById(placeId);
+    }
+
+    @Override
+    public void delete(final PlaceLike placeLike) {
+        placeLikeJpaRepository.delete(placeLike);
+    }
+
+    @Override
+    public void save(final PlaceLike newLike) {
+        placeLikeJpaRepository.save(newLike);
+    }
+
+
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Category.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Category.java
@@ -1,0 +1,25 @@
+package io.dodn.springboot.storage.db.matzip.entity;
+
+import io.dodn.springboot.storage.db.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "category")
+public class Category extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    protected Category() {
+    }
+
+    public Category(final String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Menu.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Menu.java
@@ -1,0 +1,77 @@
+package io.dodn.springboot.storage.db.matzip.entity;
+
+import io.dodn.springboot.storage.db.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "menu")
+public class Menu extends BaseEntity {
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    private String description;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "is_signature")
+    private Boolean isSignature = false;
+
+    // 여러 메뉴(N)가 하나의 맛집(1)에 속함을 나타냅니다.
+    // LAZY 로딩은 Menu 엔티티 조회 시 Place 정보를 즉시 로딩하지 않고,
+    // 실제로 place 필드를 사용할 때 로딩하여 성능을 최적화합니다. (권장)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false) // 외래 키 컬럼 지정
+    private Place place;
+
+
+    protected Menu() {
+    }
+
+    public Menu(final String name, final Integer price, final String description, final String imageUrl, final Boolean isSignature, final Place place) {
+        this.name = name;
+        this.price = price;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.isSignature = isSignature;
+        this.place = place;
+    }
+
+    // == 연관관계 편의 메서드 == //
+    // 양방향 관계에서 사용
+    public void setPlace(Place place) {
+        this.place = place;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getPrice() {
+        return price;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public Boolean getSignature() {
+        return isSignature;
+    }
+
+    public Place getPlace() {
+        return place;
+    }
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import org.locationtech.jts.geom.Point;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -30,8 +31,8 @@ public class Place extends BaseEntity {
     @Column(name = "like_count")
     private int likeCount = 0;
 
-    @Column(name = "latitude", precision = 10, scale = 8) // DB의 DECIMAL(10, 8)에 매핑
-    private BigDecimal latitude;
+    @Column(name = "location", nullable = false, columnDefinition = "POINT SRID 4326")
+    private Point location;
 
     @Column(name = "longitude", precision = 11, scale = 8) // DB의 DECIMAL(11, 8)에 매핑
     private BigDecimal longitude;
@@ -42,14 +43,13 @@ public class Place extends BaseEntity {
     protected Place() {
     }
 
-    public Place(final String name, final String address, final String phoneNumber, final String description, final int likeCount, final BigDecimal latitude, final BigDecimal longitude, final List<Menu> menus) {
+    public Place(final String name, final String address, final String phoneNumber, final String description, final int likeCount, final Point location, final List<Menu> menus) {
         this.name = name;
         this.address = address;
         this.phoneNumber = phoneNumber;
         this.description = description;
         this.likeCount = likeCount;
-        this.latitude = latitude;
-        this.longitude = longitude;
+        this.location = location;
         this.menus = menus;
     }
 
@@ -69,12 +69,8 @@ public class Place extends BaseEntity {
         return description;
     }
 
-    public BigDecimal getLatitude() {
-        return latitude;
-    }
-
-    public BigDecimal getLongitude() {
-        return longitude;
+    public Point getLocation() {
+        return location;
     }
 
     public List<Menu> getMenus() {

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
@@ -5,12 +5,17 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import org.locationtech.jts.geom.Point;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Table(name = "place")
@@ -20,6 +25,21 @@ public class Place extends BaseEntity {
 
     @Column(nullable = false)
     private String address;
+
+    @Column(name = "kiring_category")
+    private String category;
+
+    @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinTable(
+            name = "place_category", // 중간 테이블 이름
+            joinColumns = @JoinColumn(name = "place_id"), // Place 테이블을 참조하는 외래 키
+            inverseJoinColumns = @JoinColumn(name = "category_id") // Category 테이블을 참조하는 외래 키
+    )
+    private Set<Category> categories = new HashSet<>(); // Set을 사용하여 중복 카테고리 방지
+
+
+    @Column(name = "image_url", columnDefinition = "TEXT")
+    private String imageUrl;
 
     @Column(name = "phone_number")
     private String phoneNumber;
@@ -39,9 +59,11 @@ public class Place extends BaseEntity {
     protected Place() {
     }
 
-    public Place(final String name, final String address, final String phoneNumber, final String description, final int likeCount, final Point location, final List<Menu> menus) {
+    public Place(final String name, final String address, final String category, final String imageUrl, final String phoneNumber, final String description, final int likeCount, final Point location, final List<Menu> menus) {
         this.name = name;
         this.address = address;
+        this.category = category;
+        this.imageUrl = imageUrl;
         this.phoneNumber = phoneNumber;
         this.description = description;
         this.likeCount = likeCount;
@@ -69,12 +91,24 @@ public class Place extends BaseEntity {
         return location;
     }
 
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
     public List<Menu> getMenus() {
         return menus;
     }
 
     public int getLikeCount() {
         return likeCount;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategories(final Set<Category> categories) {
+        this.categories = categories;
     }
 
     // == 연관관계 편의 메서드 == //
@@ -93,5 +127,26 @@ public class Place extends BaseEntity {
         if (this.likeCount > 0) {
             this.likeCount--;
         }
+    }
+
+    public void addCategory(Category category) {
+        this.categories.add(category);
+    }
+
+
+    @Override
+    public String toString() {
+        return "Place{" +
+                "name='" + name + '\'' +
+                ", address='" + address + '\'' +
+                ", category='" + category + '\'' +
+                ", categories=" + categories +
+                ", imageUrl='" + imageUrl + '\'' +
+                ", phoneNumber='" + phoneNumber + '\'' +
+                ", description='" + description + '\'' +
+                ", likeCount=" + likeCount +
+                ", location=" + location +
+                ", menus=" + menus +
+                '}';
     }
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
@@ -1,0 +1,96 @@
+package io.dodn.springboot.storage.db.matzip.entity;
+
+import io.dodn.springboot.storage.db.common.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "place")
+public class Place extends BaseEntity {
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "like_count")
+    private int likeCount;
+
+    @Column(name = "latitude", precision = 10, scale = 8) // DB의 DECIMAL(10, 8)에 매핑
+    private BigDecimal latitude;
+
+    @Column(name = "longitude", precision = 11, scale = 8) // DB의 DECIMAL(11, 8)에 매핑
+    private BigDecimal longitude;
+
+    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Menu> menus = new ArrayList<>();
+
+    // == 연관관계 편의 메서드 == //
+    public void addMenu(Menu menu) {
+        this.menus.add(menu);
+        if (menu.getPlace() != this) {
+            menu.setPlace(this);
+        }
+    }
+
+
+    protected Place() {
+    }
+
+    public Place(final String name, final String address, final String phoneNumber, final String description, final int likeCount, final BigDecimal latitude, final BigDecimal longitude, final List<Menu> menus) {
+        this.name = name;
+        this.address = address;
+        this.phoneNumber = phoneNumber;
+        this.description = description;
+        this.likeCount = likeCount;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.menus = menus;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public List<Menu> getMenus() {
+        return menus;
+    }
+
+    public int getLikeCount() {
+        return likeCount;
+    }
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
@@ -9,7 +9,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import org.locationtech.jts.geom.Point;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,9 +32,6 @@ public class Place extends BaseEntity {
 
     @Column(name = "location", nullable = false, columnDefinition = "POINT SRID 4326")
     private Point location;
-
-    @Column(name = "longitude", precision = 11, scale = 8) // DB의 DECIMAL(11, 8)에 매핑
-    private BigDecimal longitude;
 
     @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Menu> menus = new ArrayList<>();

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
@@ -107,6 +107,10 @@ public class Place extends BaseEntity {
         return category;
     }
 
+    public Set<Category> getCategories() {
+        return categories;
+    }
+
     public void setCategories(final Set<Category> categories) {
         this.categories = categories;
     }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/Place.java
@@ -28,7 +28,7 @@ public class Place extends BaseEntity {
     private String description;
 
     @Column(name = "like_count")
-    private int likeCount;
+    private int likeCount = 0;
 
     @Column(name = "latitude", precision = 10, scale = 8) // DB의 DECIMAL(10, 8)에 매핑
     private BigDecimal latitude;
@@ -38,15 +38,6 @@ public class Place extends BaseEntity {
 
     @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Menu> menus = new ArrayList<>();
-
-    // == 연관관계 편의 메서드 == //
-    public void addMenu(Menu menu) {
-        this.menus.add(menu);
-        if (menu.getPlace() != this) {
-            menu.setPlace(this);
-        }
-    }
-
 
     protected Place() {
     }
@@ -92,5 +83,23 @@ public class Place extends BaseEntity {
 
     public int getLikeCount() {
         return likeCount;
+    }
+
+    // == 연관관계 편의 메서드 == //
+    public void addMenu(Menu menu) {
+        this.menus.add(menu);
+        if (menu.getPlace() != this) {
+            menu.setPlace(this);
+        }
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
     }
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/PlaceLike.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/PlaceLike.java
@@ -26,9 +26,19 @@ public class PlaceLike extends BaseEntity {
     @JoinColumn(name = "place_id", nullable = false)
     private Place place;
 
+    public PlaceLike() {
+    }
+
     public PlaceLike(Member member, Place place) {
         this.member = member;
         this.place = place;
     }
 
+    public Member getMember() {
+        return member;
+    }
+
+    public Place getPlace() {
+        return place;
+    }
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/PlaceLike.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/entity/PlaceLike.java
@@ -1,0 +1,34 @@
+package io.dodn.springboot.storage.db.matzip.entity;
+
+import io.dodn.springboot.storage.db.common.entity.BaseEntity;
+import io.dodn.springboot.storage.db.member.entity.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(name = "place_like",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_place_like_member_place",
+                        columnNames = {"member_id", "place_id"}
+                )
+        })
+public class PlaceLike extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+    public PlaceLike(Member member, Place place) {
+        this.member = member;
+        this.place = place;
+    }
+
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/CategoryJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/CategoryJpaRepository.java
@@ -1,0 +1,12 @@
+package io.dodn.springboot.storage.db.matzip.repository;
+
+import io.dodn.springboot.storage.db.matzip.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CategoryJpaRepository extends JpaRepository<Category, Long> {
+
+    List<Category> findByNameIn(List<String> names);
+
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/MenuJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/MenuJpaRepository.java
@@ -1,0 +1,7 @@
+package io.dodn.springboot.storage.db.matzip.repository;
+
+import io.dodn.springboot.storage.db.matzip.entity.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuJpaRepository extends JpaRepository<Menu, Long> {
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceJpaRepository.java
@@ -22,7 +22,8 @@ public interface PlaceJpaRepository extends JpaRepository<Place, Long> {
                     " p.id AS placeId, p.name, p.address, p.address, p.description, " +
                     " ST_X(p.location) AS longitude, " +
                     " ST_Y(p.location) AS latitude, " +
-                    " ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) AS distance " +
+                    " ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) AS distance, " +
+                    " p.phone_number AS phoneNumber " +
                     "FROM place p " +
                     "WHERE ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) <= :radius " +
                     "ORDER BY distance " +

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceJpaRepository.java
@@ -1,8 +1,34 @@
 package io.dodn.springboot.storage.db.matzip.repository;
 
+import io.dodn.springboot.storage.db.matzip.PlaceWithDistance;
 import io.dodn.springboot.storage.db.matzip.entity.Place;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PlaceJpaRepository extends JpaRepository<Place, Long> {
+
+    @Query(
+            value = "SELECT count(*) FROM place p WHERE ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) <= :radius",
+            nativeQuery = true
+    )
+    long countNearbyPlaces(@Param("point") String point, @Param("radius") int radius);
+
+    @Query(
+            value = "SELECT " +
+                    " p.id AS placeId, p.name, p.address, p.address, p.description, " +
+                    " ST_X(p.location) AS longitude, " +
+                    " ST_Y(p.location) AS latitude, " +
+                    " ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) AS distance " +
+                    "FROM place p " +
+                    "WHERE ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) <= :radius " +
+                    "ORDER BY distance " +
+                    "LIMIT :#{#pageable.pageSize} OFFSET :#{#pageable.offset}",
+            nativeQuery = true
+    )
+    List<PlaceWithDistance> findNearbyPlaces(@Param("point") String point, @Param("radius") int radius, Pageable pageable);
 
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceJpaRepository.java
@@ -25,21 +25,6 @@ public interface PlaceJpaRepository extends JpaRepository<Place, Long> {
     )
     long countNearbyPlaces(@Param("point") String point, @Param("radius") int radius);
 
-//    @Query(
-//            value = "SELECT " +
-//                    " p.id AS placeId, p.name, p.address, p.address, p.description, " +
-//                    " ST_X(p.location) AS longitude, " +
-//                    " ST_Y(p.location) AS latitude, " +
-//                    " ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) AS distance, " +
-//                    " p.phone_number AS phoneNumber " +
-//                    "FROM place p " +
-//                    "WHERE ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) <= :radius " +
-//                    "ORDER BY distance " +
-//                    "LIMIT :#{#pageable.pageSize} OFFSET :#{#pageable.offset}",
-//            nativeQuery = true
-//    )
-//    List<PlaceWithDistance> findNearbyPlaces(@Param("point") String point, @Param("radius") int radius, Pageable pageable);
-
     @Query(value = "SELECT DISTINCT p FROM Place p LEFT JOIN FETCH p.categories",
             countQuery = "SELECT COUNT(p) FROM Place p")
     Page<Place> findAllWithCategories(Pageable pageable);
@@ -61,10 +46,10 @@ public interface PlaceJpaRepository extends JpaRepository<Place, Long> {
     )
     List<PlaceWithDistance> findNearbyPlacesOrderByLikeCount(@Param("point") String point, @Param("radius") int radius, Pageable pageable);
 
-    // 이름순 정렬
+    // 최신순 정렬
     @Query(
             value = SELECT_CLAUSE + FROM_WHERE_CLAUSE +
-                    "ORDER BY p.name ASC, distance ASC " ,
+                    "ORDER BY p.id desc, distance ASC " ,
             nativeQuery = true
     )
     List<PlaceWithDistance> findNearbyPlacesOrderByName(@Param("point") String point, @Param("radius") int radius, Pageable pageable);

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceJpaRepository.java
@@ -2,6 +2,7 @@ package io.dodn.springboot.storage.db.matzip.repository;
 
 import io.dodn.springboot.storage.db.matzip.PlaceWithDistance;
 import io.dodn.springboot.storage.db.matzip.entity.Place;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,6 +11,13 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface PlaceJpaRepository extends JpaRepository<Place, Long> {
+    // 공통 SELECT 구문 정의 (중복 제거)
+    String SELECT_CLAUSE = "SELECT " +
+            "p.id AS placeId, p.name, p.address, p.phone_number AS phoneNumber, p.like_count AS likeCount, " +
+            "ST_X(p.location) AS longitude, ST_Y(p.location) AS latitude, " +
+            "ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) AS distance ";
+    String FROM_WHERE_CLAUSE = "FROM place p WHERE ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) <= :radius ";
+
 
     @Query(
             value = "SELECT count(*) FROM place p WHERE ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) <= :radius",
@@ -17,19 +25,48 @@ public interface PlaceJpaRepository extends JpaRepository<Place, Long> {
     )
     long countNearbyPlaces(@Param("point") String point, @Param("radius") int radius);
 
+//    @Query(
+//            value = "SELECT " +
+//                    " p.id AS placeId, p.name, p.address, p.address, p.description, " +
+//                    " ST_X(p.location) AS longitude, " +
+//                    " ST_Y(p.location) AS latitude, " +
+//                    " ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) AS distance, " +
+//                    " p.phone_number AS phoneNumber " +
+//                    "FROM place p " +
+//                    "WHERE ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) <= :radius " +
+//                    "ORDER BY distance " +
+//                    "LIMIT :#{#pageable.pageSize} OFFSET :#{#pageable.offset}",
+//            nativeQuery = true
+//    )
+//    List<PlaceWithDistance> findNearbyPlaces(@Param("point") String point, @Param("radius") int radius, Pageable pageable);
+
+    @Query(value = "SELECT DISTINCT p FROM Place p LEFT JOIN FETCH p.categories",
+            countQuery = "SELECT COUNT(p) FROM Place p")
+    Page<Place> findAllWithCategories(Pageable pageable);
+
+
+    // 거리순 정렬 (기본)
     @Query(
-            value = "SELECT " +
-                    " p.id AS placeId, p.name, p.address, p.address, p.description, " +
-                    " ST_X(p.location) AS longitude, " +
-                    " ST_Y(p.location) AS latitude, " +
-                    " ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) AS distance, " +
-                    " p.phone_number AS phoneNumber " +
-                    "FROM place p " +
-                    "WHERE ST_Distance_Sphere(p.location, ST_PointFromText(:point, 4326)) <= :radius " +
-                    "ORDER BY distance " +
-                    "LIMIT :#{#pageable.pageSize} OFFSET :#{#pageable.offset}",
+            value = SELECT_CLAUSE + FROM_WHERE_CLAUSE +
+                    "ORDER BY distance ASC, p.like_count DESC ",
             nativeQuery = true
     )
-    List<PlaceWithDistance> findNearbyPlaces(@Param("point") String point, @Param("radius") int radius, Pageable pageable);
+    List<PlaceWithDistance> findNearbyPlacesOrderByDistance(@Param("point") String point, @Param("radius") int radius, Pageable pageable);
+
+    // 좋아요순 정렬
+    @Query(
+            value = SELECT_CLAUSE + FROM_WHERE_CLAUSE +
+                    "ORDER BY p.like_count DESC, distance ASC " ,
+            nativeQuery = true
+    )
+    List<PlaceWithDistance> findNearbyPlacesOrderByLikeCount(@Param("point") String point, @Param("radius") int radius, Pageable pageable);
+
+    // 이름순 정렬
+    @Query(
+            value = SELECT_CLAUSE + FROM_WHERE_CLAUSE +
+                    "ORDER BY p.name ASC, distance ASC " ,
+            nativeQuery = true
+    )
+    List<PlaceWithDistance> findNearbyPlacesOrderByName(@Param("point") String point, @Param("radius") int radius, Pageable pageable);
 
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceJpaRepository.java
@@ -1,0 +1,8 @@
+package io.dodn.springboot.storage.db.matzip.repository;
+
+import io.dodn.springboot.storage.db.matzip.entity.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceJpaRepository extends JpaRepository<Place, Long> {
+
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceLikeJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceLikeJpaRepository.java
@@ -1,0 +1,18 @@
+package io.dodn.springboot.storage.db.matzip.repository;
+
+import io.dodn.springboot.storage.db.matzip.entity.PlaceLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
+
+public interface PlaceLikeJpaRepository extends JpaRepository<PlaceLike, Long> {
+
+    // 특정 사용자가 주어진 여러 맛집 ID들 중에서 좋아요를 누른 맛집의 ID 목록만 조회
+    // 반환 타입을 Set으로 하면 중복 없이 빠르게 '포함 여부'를 확인할 수 있습니다.
+    @Query("SELECT pl.place.id FROM PlaceLike pl WHERE pl.member.id = :memberId AND pl.place.id IN :placeIds")
+    Set<Long> findLikedPlaceIdsByMemberAndPlaceIds(@Param("memberId") Long memberId, @Param("placeIds") List<Long> placeIds);
+
+}

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceLikeJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/matzip/repository/PlaceLikeJpaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface PlaceLikeJpaRepository extends JpaRepository<PlaceLike, Long> {
@@ -15,4 +16,5 @@ public interface PlaceLikeJpaRepository extends JpaRepository<PlaceLike, Long> {
     @Query("SELECT pl.place.id FROM PlaceLike pl WHERE pl.member.id = :memberId AND pl.place.id IN :placeIds")
     Set<Long> findLikedPlaceIdsByMemberAndPlaceIds(@Param("memberId") Long memberId, @Param("placeIds") List<Long> placeIds);
 
+    Optional<PlaceLike> findByMemberIdAndPlaceId(Long memberId, Long placeId);
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/member/MemberRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/member/MemberRepository.java
@@ -26,4 +26,6 @@ public interface MemberRepository {
     long count();
 
     Optional<Member> findByPhone(String s);
+
+    List<Member> findMembersWithBirthdayInMonth(String monthString);
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/member/adapter/MemberRepositoryAdapter.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/member/adapter/MemberRepositoryAdapter.java
@@ -70,5 +70,10 @@ public class MemberRepositoryAdapter implements MemberRepository {
         return memberJpaRepository.findByPhone(s);
     }
 
+    @Override
+    public List<Member> findMembersWithBirthdayInMonth(final String monthString) {
+        return memberJpaRepository.findMembersWithBirthdayInMonth(monthString);
+    }
+
 
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/member/entity/Member.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/member/entity/Member.java
@@ -122,6 +122,10 @@ public class Member extends BaseEntity {
         return team;
     }
 
+    public LocalDate getJoinedAt() {
+        return joinedAt;
+    }
+
     private static final String EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
 
 

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/member/entity/Member.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/member/entity/Member.java
@@ -36,7 +36,7 @@ public class Member extends BaseEntity {
     private String kiringImageUrl;
 
     @Column(name = "birthday")
-    private LocalDate birthday;
+    private String birthday;
 
     @Column(name = "github_id")
     private String githubId;
@@ -47,16 +47,18 @@ public class Member extends BaseEntity {
     @Column(name = "is_admin")
     private boolean isAdmin;
 
+    @Column(name = "joined_at")
+    private LocalDate joinedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false) // MEMBER 테이블의 team_id 컬럼과 매핑, NULL
-                                                    // 비허용
     private Team team;
 
     protected Member() {
     }
 
     public Member(String name, String email, String phone, String kakaoId, String nickname, String profileImageUrl, final String kiringImageUrl,
-                  LocalDate birthday, String githubId, boolean isEmployed, boolean isAdmin, Team team) {
+                  String birthday, String githubId, boolean isEmployed, boolean isAdmin, final LocalDate joinedAt, Team team) {
         this.name = name;
         this.email = email;
         this.phone = phone;
@@ -68,6 +70,7 @@ public class Member extends BaseEntity {
         this.githubId = githubId;
         this.isEmployed = isEmployed;
         this.isAdmin = isAdmin;
+        this.joinedAt = joinedAt;
         this.team = team;
     }
 
@@ -99,7 +102,7 @@ public class Member extends BaseEntity {
         return profileImageUrl;
     }
 
-    public LocalDate getBirthday() {
+    public String getBirthday() {
         return birthday;
     }
 
@@ -181,6 +184,12 @@ public class Member extends BaseEntity {
         }
         if (member.githubId != null && !member.githubId.isBlank()) {
             this.githubId = member.githubId;
+        }
+        if (member.joinedAt != null) {
+            this.joinedAt = member.joinedAt;
+        }
+        if (member.team != null) {
+            this.team = member.team;
         }
         this.isEmployed = member.isEmployed;
     }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/member/repository/MemberJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/member/repository/MemberJpaRepository.java
@@ -22,4 +22,7 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     List<Member> findMembersAndFetchTeamByTeamId(@Param("teamId") Long teamId);
 
     Optional<Member> findByPhone(String s);
+
+    @Query("SELECT m FROM Member m WHERE SUBSTRING(m.birthday, 1, 2) = :monthString")
+    List<Member> findMembersWithBirthdayInMonth(@Param("monthString") String monthString);
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/PlaneRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/PlaneRepository.java
@@ -1,11 +1,15 @@
 package io.dodn.springboot.storage.db.plane;
 
+import io.dodn.springboot.storage.db.member.entity.Member;
 import io.dodn.springboot.storage.db.plane.entity.Plane;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PlaneRepository {
     Plane save(Plane plane);
 
     List<Plane> findByReceiverId(long readerId);
+
+    boolean existsBySenderAndCreatedAtBetween(Member sender, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/PlaneRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/PlaneRepository.java
@@ -12,4 +12,6 @@ public interface PlaneRepository {
     List<Plane> findByReceiverId(long readerId);
 
     boolean existsBySenderAndCreatedAtBetween(Member sender, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+    List<Plane> findByReceiverIdAndCreatedAtBetween(long readerId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/adapter/PlaneRepositoryAdapter.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/adapter/PlaneRepositoryAdapter.java
@@ -34,4 +34,9 @@ public class PlaneRepositoryAdapter implements PlaneRepository {
     public boolean existsBySenderAndCreatedAtBetween(final Member sender, final LocalDateTime startOfDay, final LocalDateTime endOfDay) {
         return planeJpaRepository.existsBySenderAndCreatedAtBetween(sender, startOfDay, endOfDay);
     }
+
+    @Override
+    public List<Plane> findByReceiverIdAndCreatedAtBetween(final long readerId, final LocalDateTime startOfDay, final LocalDateTime endOfDay) {
+        return planeJpaRepository.findByReceiverIdAndCreatedAtBetween(readerId, startOfDay, endOfDay);
+    }
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/adapter/PlaneRepositoryAdapter.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/adapter/PlaneRepositoryAdapter.java
@@ -1,11 +1,13 @@
 package io.dodn.springboot.storage.db.plane.adapter;
 
+import io.dodn.springboot.storage.db.member.entity.Member;
 import io.dodn.springboot.storage.db.member.repository.MemberJpaRepository;
 import io.dodn.springboot.storage.db.plane.PlaneRepository;
 import io.dodn.springboot.storage.db.plane.entity.Plane;
 import io.dodn.springboot.storage.db.plane.repository.PlaneJpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -25,6 +27,11 @@ public class PlaneRepositoryAdapter implements PlaneRepository {
 
     @Override
     public List<Plane> findByReceiverId(final long readerId) {
-        return planeJpaRepository.findAllByReceiverId(readerId);
+        return planeJpaRepository.findAllByReceiverIdOrderByCreatedAtDesc(readerId);
+    }
+
+    @Override
+    public boolean existsBySenderAndCreatedAtBetween(final Member sender, final LocalDateTime startOfDay, final LocalDateTime endOfDay) {
+        return planeJpaRepository.existsBySenderAndCreatedAtBetween(sender, startOfDay, endOfDay);
     }
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/repository/PlaneJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/repository/PlaneJpaRepository.java
@@ -11,4 +11,6 @@ public interface PlaneJpaRepository extends JpaRepository<Plane, Long>{
     List<Plane> findAllByReceiverIdOrderByCreatedAtDesc(long readerId);
 
     boolean existsBySenderAndCreatedAtBetween(Member sender, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+    List<Plane> findByReceiverIdAndCreatedAtBetween(long readerId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/repository/PlaneJpaRepository.java
+++ b/storage/db-core/src/main/java/io/dodn/springboot/storage/db/plane/repository/PlaneJpaRepository.java
@@ -1,10 +1,14 @@
 package io.dodn.springboot.storage.db.plane.repository;
 
+import io.dodn.springboot.storage.db.member.entity.Member;
 import io.dodn.springboot.storage.db.plane.entity.Plane;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PlaneJpaRepository extends JpaRepository<Plane, Long>{
-    List<Plane> findAllByReceiverId(long readerId);
+    List<Plane> findAllByReceiverIdOrderByCreatedAtDesc(long readerId);
+
+    boolean existsBySenderAndCreatedAtBetween(Member sender, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/storage/db-core/src/main/resources/db-core.yml
+++ b/storage/db-core/src/main/resources/db-core.yml
@@ -2,7 +2,7 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate.default_batch_fetch_size: 100
 

--- a/storage/db-core/src/main/resources/db-core.yml
+++ b/storage/db-core/src/main/resources/db-core.yml
@@ -31,6 +31,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
+        geometry_factory: org.hibernate.spatial.integration.jts.JtsGeometryFactory
         format_sql: true
         show_sql: true
   h2:


### PR DESCRIPTION
## 🚀 기능 추가 / 개선 사항 | 🐞 버그 수정 | 🛠 리팩토링 개요

<!-- 기능에 맞게 위의 셋 중에 하나를 골라서 제목을 설정해주세요. -->
<!-- 이번 PR에서 추가된 기능을 설명해주세요. -->
<!-- 어떤 문제가 있었고, 어떻게 해결했는지 설명해주세요. -->
<!-- 어떤 부분을 리팩토링했는지 설명해주세요. -->

- 맛집 API 추가개발
- 지도관련 공간 인덱스 사용
- 카카오톡 로그인 로직 추가수정
- 에러로직 통일

## 🏗 작업 내용 | 🔍 해결 방법 | 🧐 주요 변경 사항

- [ ] 맛집 API 추가개발
- [ ] 지도관련 공간 인덱스 사용
- [ ] 카카오톡 로그인 로직 추가수정
- [ ] 에러로직 통일


## 👀 관련 이슈 번호

- #4 , #7 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 맛집(Place) 관련 REST API 추가: 전체 목록 조회, 좋아요 토글, 주변 맛집 검색 기능 제공.
  - 맛집, 메뉴, 좋아요, 카테고리 엔티티 및 데이터 모델 도입.
  - 이벤트 월별 조회 API 추가: 특정 연월 이벤트 및 생일 정보 확인 가능.
  - 멤버 이미지 URL 조회 API 신규 도입 및 멤버 조회 경로 정비.
  - 플레인 메시지 조회 및 오늘 메시지 확인 API 추가.
  - 엑셀 파일 업로드를 통한 맛집 데이터 일괄 등록 기능 추가.
  - 인증 토큰 리프레시 API 및 서비스 추가.
  - OAuth2 로그인 시 커스텀 파라미터 추가.
  - Swagger 문서 보강 및 신규 인터페이스 추가.

- **Improvements**
  - API 경로를 `/api/v1` 하위로 통합해 일관성 강화.
  - API 에러 코드 및 메시지 표준화로 명확한 오류 응답 제공.
  - 멤버 생일 필드를 문자열로 변경하고 가입일 필드 추가.
  - 멤버 정보 수정 시 팀 정보 조건부 업데이트 반영.
  - CORS 설정에 와일드카드 서브도메인 패턴 허용 추가.
  - 로그인 성공 후 에러 발생 시 표준화된 에러 코드와 메시지로 리다이렉트 처리.
  - 플레인 메시지 발송 하루 1회 제한 로직 도입(주석 상태).
  - 헬스 체크 API 경로를 `/api/v1/health/health`로 변경.
  - OpenAPI 서버 URL을 도메인 기반 HTTPS로 변경.
  - 플레인 메시지 읽기 API가 사용자 ID 기반 조회로 변경되어 안정성 향상.
  - 리프레시 토큰 만료 기간을 30일로 연장.
  - 빌드 설정에 Apache POI 라이브러리 추가로 Excel 파일 처리 지원.
  - 기존 예제 컨트롤러에 `@Deprecated` 애노테이션 추가.
  - JPA Hibernate 스키마 생성 전략을 `create`에서 `update`로 변경.
  - GitHub Actions EC2 배포 시 Docker 포트 매핑을 8080으로 수정.

- **Bug Fixes**
  - 전화번호가 없는 경우 명확한 예외 및 에러 코드 처리 추가.

- **Documentation**
  - Swagger/OpenAPI 문서 보강으로 API 사용성 향상.
  - 멤버, 맛집, 플레인 관련 API에 상세 응답 및 파라미터 설명 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->